### PR TITLE
Allow trailing semicolon on connect string

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -108,8 +108,10 @@ class Mysqldump
         $data = [];
 
         foreach (explode(';', substr($dsn, $pos + 1)) as $kvp) {
-            list($param, $value) = explode('=', $kvp);
-            $data[strtolower($param)] = $value;
+            if (strpos($kvp, '=') !== false) {
+                list($param, $value) = explode('=', $kvp);
+                $data[strtolower($param)] = $value;
+            }
         }
 
         if (empty($data['host']) && empty($data['unix_socket'])) {

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -110,7 +110,7 @@ class Mysqldump
         foreach (explode(';', substr($dsn, $pos + 1)) as $kvp) {
             if (strpos($kvp, '=') !== false) {
                 list($param, $value) = explode('=', $kvp);
-                $data[strtolower($param)] = $value;
+                $data[trim(strtolower($param))] = $value;
             }
         }
 

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -36,9 +36,63 @@ class MysqldumpTest extends TestCase
     /**
      * @covers Mysqldump
      */
+    public function testDSNWorks()
+    {
+        $user = 'user';
+        $pass = 'password';
+        $host = 'localhost';
+        $dbName = 'test';
+        $dsn = "mysql: host={$host}; dbname={$dbName};";
+        $dump = new Mysqldump($dsn, $user, $pass);
+        $this->assertEquals($dsn, $this->getPrivate($dump, 'dsn'), 'dsn is not set correctly');
+        $this->assertEquals($user, $this->getPrivate($dump, 'user'), 'user is not set correctly');
+        $this->assertEquals($pass, $this->getPrivate($dump, 'pass'), 'pass is not set correctly');
+        $this->assertEquals($host, $this->getPrivate($dump, 'host'), 'host is not set correctly');
+        $this->assertEquals($dbName, $this->getPrivate($dump, 'dbName'), 'dbName is not set correctly');
+    }
+
+  /**
+     * @covers Mysqldump
+     */
+    public function testDSNStringExits()
+    {
+        $this->expectException(\Exception::class);
+        $dump = new Mysqldump('', 'testing', 'testing');
+    }
+
+    /**
+     * @covers Mysqldump
+     */
+    public function testHostExits()
+    {
+        $this->expectException(\Exception::class);
+        $dump = new Mysqldump('mysql: dbname=test;', 'testing', 'testing');
+    }
+
+    /**
+     * @covers Mysqldump
+     */
+    public function testDBTypeExists()
+    {
+        $this->expectException(\Exception::class);
+        $dump = new Mysqldump('host=localhost; dbname=test;', 'testing', 'testing');
+    }
+
+    /**
+     * @covers Mysqldump
+     */
+    public function testDBNameExists()
+    {
+        $this->expectException(\Exception::class);
+        $dump = new Mysqldump('mysql: host=localhost', 'testing', 'testing');
+    }
+
+    /**
+     * @covers Mysqldump
+     */
     public function testTableSpecificLimitsWork()
     {
-        $dump = new Mysqldump('mysql:host=localhost;dbname=test;', 'testing', 'testing');
+        $dump = new Mysqldump('mysql: host=localhost; dbname=test;', 'testing', 'testing');
 
         $dump->setTableLimits([
             'users' => 200,
@@ -50,5 +104,11 @@ class MysqldumpTest extends TestCase
         $this->assertEquals(500, $dump->getTableLimit('logs'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_limit'));
         $this->assertFalse($dump->getTableLimit('table_name_with_no_limit'));
+    }
+
+    private function getPrivate(Mysqldump $dump, $var)
+    {
+        $reflectionProperty = new \ReflectionProperty(Mysqldump::class, $var);
+        return $reflectionProperty->getValue($dump);
     }
 }

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -38,7 +38,7 @@ class MysqldumpTest extends TestCase
      */
     public function testTableSpecificLimitsWork()
     {
-        $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'testing', 'testing');
+        $dump = new Mysqldump('mysql:host=localhost;dbname=test;', 'testing', 'testing');
 
         $dump->setTableLimits([
             'users' => 200,

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -109,6 +109,7 @@ class MysqldumpTest extends TestCase
     private function getPrivate(Mysqldump $dump, $var)
     {
         $reflectionProperty = new \ReflectionProperty(Mysqldump::class, $var);
+        $reflectionProperty->setAccessible(true);
         return $reflectionProperty->getValue($dump);
     }
 }


### PR DESCRIPTION
It is valid in PDO to allow a trailing semicolon on the connection string.  Currently there is an error generated for this case.  This PR was originally posted to the Ifsnop project, but never merged.

Added a semicolon to the test connect string in the unit tests.