### PR TITLE
table limit range support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,15 @@ $dumper->setTableLimits([
     'posts' => 10
 ]);
 ```
+You can also specify the limits as an array where the first value is the number of rows and the second is the offset
 
+```php
+$dumper = new \Druidfi\Mysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
+
+$dumper->setTableLimits([
+    'users' => [20, 10], //MySql query equivalent "... LIMIT 20 OFFSET 10"
+]);
+```
 ## Dump Settings
 
 Dump settings can be changed from default values with 4th argument for Mysqldump constructor:

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -1040,18 +1040,20 @@ class Mysqldump
             return false;
         }
 
-        $v = false;
+        $limit = false;
         if (is_numeric($this->tableLimits[$tableName])) {
-            $v = is_numeric($this->tableLimits[$tableName]);
+            $limit = $this->tableLimits[$tableName];
         }
 
         if (is_array($this->tableLimits[$tableName]) &&
             count($this->tableLimits[$tableName]) === 2 &&
-            is_numeric(implode('', $this->tableLimits[$tableName]))) {
-            $v = implode(',', $this->tableLimits[$tableName]);
+            is_numeric(implode('', $this->tableLimits[$tableName])) &&
+            $this->tableLimits[$tableName][0] <= $this->tableLimits[$tableName][1]
+        ) {
+            $limit = implode(',', $this->tableLimits[$tableName]);
         }
 
-        return $v;
+        return $limit;
 
     }
 

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -1041,20 +1041,19 @@ class Mysqldump
         }
 
         $limit = false;
+
         if (is_numeric($this->tableLimits[$tableName])) {
             $limit = $this->tableLimits[$tableName];
         }
 
         if (is_array($this->tableLimits[$tableName]) &&
             count($this->tableLimits[$tableName]) === 2 &&
-            is_numeric(implode('', $this->tableLimits[$tableName])) &&
-            $this->tableLimits[$tableName][0] <= $this->tableLimits[$tableName][1]
+            is_numeric(implode('', $this->tableLimits[$tableName]))
         ) {
             $limit = implode(',', $this->tableLimits[$tableName]);
         }
 
         return $limit;
-
     }
 
     /**

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -75,7 +75,8 @@ class Mysqldump
         ?string $pass = null,
         array   $settings = [],
         array   $pdoOptions = []
-    ) {
+    )
+    {
         $this->dsn = $this->parseDsn($dsn);
         $this->user = $user;
         $this->pass = $pass;
@@ -247,20 +248,20 @@ class Mysqldump
     {
         // Some info about software, source and time
         $header = sprintf(
-            "-- mysqldump-php https://github.com/druidfi/mysqldump-php". PHP_EOL.
-            "--". PHP_EOL.
-            "-- Host: %s\tDatabase: %s". PHP_EOL.
-            "-- ------------------------------------------------------". PHP_EOL,
+            "-- mysqldump-php https://github.com/druidfi/mysqldump-php" . PHP_EOL .
+            "--" . PHP_EOL .
+            "-- Host: %s\tDatabase: %s" . PHP_EOL .
+            "-- ------------------------------------------------------" . PHP_EOL,
             $this->host,
             $this->dbName
         );
 
         if (!empty($version = $this->db->getVersion())) {
-            $header .= "-- Server version \t". $version . PHP_EOL;
+            $header .= "-- Server version \t" . $version . PHP_EOL;
         }
 
         if (!$this->settings->skipDumpDate()) {
-            $header .= "-- Date: ".date('r'). PHP_EOL . PHP_EOL;
+            $header .= "-- Date: " . date('r') . PHP_EOL . PHP_EOL;
         }
 
         return $header;
@@ -274,7 +275,7 @@ class Mysqldump
         $footer = '-- Dump completed';
 
         if (!$this->settings->skipDumpDate()) {
-            $footer .= ' on: '.date('r');
+            $footer .= ' on: ' . date('r');
         }
 
         $footer .= PHP_EOL;
@@ -508,9 +509,9 @@ class Mysqldump
 
             if (!$this->settings->skipComments()) {
                 $ret = sprintf(
-                    "--".PHP_EOL.
-                    "-- Table structure for table `%s`".PHP_EOL.
-                    "--".PHP_EOL.PHP_EOL,
+                    "--" . PHP_EOL .
+                    "-- Table structure for table `%s`" . PHP_EOL .
+                    "--" . PHP_EOL . PHP_EOL,
                     $tableName
                 );
             }
@@ -548,7 +549,7 @@ class Mysqldump
         foreach ($columns as $col) {
             $types = $this->db->parseColumnType($col);
             $columnTypes[$col['Field']] = [
-                'is_numeric'=> $types['is_numeric'],
+                'is_numeric' => $types['is_numeric'],
                 'is_blob' => $types['is_blob'],
                 'type' => $types['type'],
                 'type_sql' => $col['Type'],
@@ -608,7 +609,7 @@ class Mysqldump
         $ret = implode(PHP_EOL . ',', $ret);
 
         return sprintf(
-            "CREATE TABLE IF NOT EXISTS `%s` (".PHP_EOL."%s".PHP_EOL.");".PHP_EOL,
+            "CREATE TABLE IF NOT EXISTS `%s` (" . PHP_EOL . "%s" . PHP_EOL . ");" . PHP_EOL,
             $viewName,
             $ret
         );
@@ -621,9 +622,9 @@ class Mysqldump
     {
         if (!$this->settings->skipComments()) {
             $ret = sprintf(
-                "--". PHP_EOL.
-                "-- View structure for view `%s`". PHP_EOL.
-                "--". PHP_EOL . PHP_EOL,
+                "--" . PHP_EOL .
+                "-- View structure for view `%s`" . PHP_EOL .
+                "--" . PHP_EOL . PHP_EOL,
                 $viewName
             );
 
@@ -670,9 +671,9 @@ class Mysqldump
     private function getProcedureStructure(string $procedureName)
     {
         if (!$this->settings->skipComments()) {
-            $ret = "--".PHP_EOL.
-                "-- Dumping routines for database '".$this->dbName."'".PHP_EOL.
-                "--".PHP_EOL.PHP_EOL;
+            $ret = "--" . PHP_EOL .
+                "-- Dumping routines for database '" . $this->dbName . "'" . PHP_EOL .
+                "--" . PHP_EOL . PHP_EOL;
             $this->write($ret);
         }
 
@@ -693,9 +694,9 @@ class Mysqldump
     private function getFunctionStructure(string $functionName)
     {
         if (!$this->settings->skipComments()) {
-            $ret = "--".PHP_EOL.
-                "-- Dumping routines for database '".$this->dbName."'".PHP_EOL.
-                "--".PHP_EOL.PHP_EOL;
+            $ret = "--" . PHP_EOL .
+                "-- Dumping routines for database '" . $this->dbName . "'" . PHP_EOL .
+                "--" . PHP_EOL . PHP_EOL;
             $this->write($ret);
         }
 
@@ -717,9 +718,9 @@ class Mysqldump
     private function getEventStructure(string $eventName)
     {
         if (!$this->settings->skipComments()) {
-            $ret = "--".PHP_EOL.
-                "-- Dumping events for database '".$this->dbName."'".PHP_EOL.
-                "--".PHP_EOL.PHP_EOL;
+            $ret = "--" . PHP_EOL .
+                "-- Dumping events for database '" . $this->dbName . "'" . PHP_EOL .
+                "--" . PHP_EOL . PHP_EOL;
             $this->write($ret);
         }
 
@@ -799,7 +800,7 @@ class Mysqldump
             $colNames = $this->getColumnNames($tableName);
         }
 
-        $stmt = "SELECT ".implode(",", $colStmt)." FROM `$tableName`";
+        $stmt = "SELECT " . implode(",", $colStmt) . " FROM `$tableName`";
 
         // Table specific conditions override the default 'where'
         $condition = $this->getTableWhere($tableName);
@@ -871,9 +872,9 @@ class Mysqldump
     {
         if (!$this->settings->skipComments()) {
             $this->write(
-                "--".PHP_EOL.
-                "-- Dumping data for table `$tableName`".PHP_EOL.
-                "--".PHP_EOL.PHP_EOL
+                "--" . PHP_EOL .
+                "-- Dumping data for table `$tableName`" . PHP_EOL .
+                "--" . PHP_EOL . PHP_EOL
             );
         }
 
@@ -934,8 +935,8 @@ class Mysqldump
 
         if (!$this->settings->skipComments()) {
             $this->write(
-                "-- Dumped table `".$tableName."` with $count row(s)".PHP_EOL.
-                '--'.PHP_EOL.PHP_EOL
+                "-- Dumped table `" . $tableName . "` with $count row(s)" . PHP_EOL .
+                '--' . PHP_EOL . PHP_EOL
             );
         }
     }
@@ -1035,7 +1036,19 @@ class Mysqldump
             return false;
         }
 
-        return is_numeric($this->tableLimits[$tableName]) ? $this->tableLimits[$tableName] : false;
+        $v = false;
+        if (is_numeric($this->tableLimits[$tableName])) {
+            $v = is_numeric($this->tableLimits[$tableName]);
+        }
+
+        if (is_array($this->tableLimits[$tableName]) &&
+            count($this->tableLimits[$tableName]) === 2 &&
+            is_numeric(implode('', $this->tableLimits[$tableName]))) {
+            $v = implode(', ', $this->tableLimits[$tableName]);
+        }
+
+        return $v;
+
     }
 
     /**

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -812,7 +812,9 @@ class Mysqldump
         }
 
         if ($limit = $this->getTableLimit($tableName)) {
-            $stmt .= is_numeric($limit) ? sprintf(' LIMIT %d', $limit) : sprintf(' LIMIT %s', $limit);
+            $stmt .= is_numeric($limit) ?
+                sprintf(' LIMIT %d', $limit) :
+                sprintf(' LIMIT %s', $limit);
         }
 
         $resultSet = $this->conn->query($stmt);

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -812,7 +812,7 @@ class Mysqldump
         }
 
         if ($limit = $this->getTableLimit($tableName)) {
-            $stmt .= sprintf(' LIMIT %d', $limit);
+            $stmt .= is_numeric($limit) ? sprintf(' LIMIT %d', $limit) : sprintf(' LIMIT %s', $limit);
         }
 
         $resultSet = $this->conn->query($stmt);

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -1046,7 +1046,7 @@ class Mysqldump
         if (is_array($this->tableLimits[$tableName]) &&
             count($this->tableLimits[$tableName]) === 2 &&
             is_numeric(implode('', $this->tableLimits[$tableName]))) {
-            $v = implode(', ', $this->tableLimits[$tableName]);
+            $v = implode(',', $this->tableLimits[$tableName]);
         }
 
         return $v;

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -98,22 +98,21 @@ class MysqldumpTest extends TestCase
             'users' => 200,
             'logs' => 500,
             'table_with_invalid_limit' => '41923, 42992',
-            'table_with_range_limit' => [41923, 42992],
-            'table_with_invalid_range_limit' => [41923],
-            'table_with_invalid_range_limit2' => [41923, 42992, 42999],
-            'table_with_invalid_range_limit3' => [2, 1],
-            'table_with_invalid_range_limit4' => [1, 1],
+            'table_with_range_limit' => [100, 300],
+            'table_with_range_limit2' => [1, 1],
+            'table_with_invalid_range_limit' => [100],
+            'table_with_invalid_range_limit2' => [100, 300, 400],
+
         ]);
 
         $this->assertEquals(200, $dump->getTableLimit('users'));
         $this->assertEquals(500, $dump->getTableLimit('logs'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_limit'));
         $this->assertFalse($dump->getTableLimit('table_name_with_no_limit'));
-        $this->assertEquals('41923,42992', $dump->getTableLimit('table_with_range_limit'));
+        $this->assertEquals('100,300', $dump->getTableLimit('table_with_range_limit'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit2'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit3'));
-        $this->assertEquals('1,1', $dump->getTableLimit('table_with_invalid_range_limit4'));
     }
 
     private function getPrivate(Mysqldump $dump, $var)

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -101,6 +101,8 @@ class MysqldumpTest extends TestCase
             'table_with_range_limit' => [41923, 42992],
             'table_with_invalid_range_limit' => [41923],
             'table_with_invalid_range_limit2' => [41923, 42992, 42999],
+            'table_with_invalid_range_limit3' => [2, 1],
+            'table_with_invalid_range_limit4' => [1, 1],
         ]);
 
         $this->assertEquals(200, $dump->getTableLimit('users'));
@@ -110,6 +112,8 @@ class MysqldumpTest extends TestCase
         $this->assertEquals('41923,42992', $dump->getTableLimit('table_with_range_limit'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit2'));
+        $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit3'));
+        $this->assertEquals('1,1', $dump->getTableLimit('table_with_invalid_range_limit4'));
     }
 
     private function getPrivate(Mysqldump $dump, $var)

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -107,7 +107,7 @@ class MysqldumpTest extends TestCase
         $this->assertEquals(500, $dump->getTableLimit('logs'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_limit'));
         $this->assertFalse($dump->getTableLimit('table_name_with_no_limit'));
-        $this->assertEquals('41923, 42992', $dump->getTableLimit('table_with_range_limit'));
+        $this->assertEquals('41923,42992', $dump->getTableLimit('table_with_range_limit'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit2'));
     }

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -43,12 +43,18 @@ class MysqldumpTest extends TestCase
         $dump->setTableLimits([
             'users' => 200,
             'logs' => 500,
-            'table_with_invalid_limit' => '41923, 42992'
+            'table_with_invalid_limit' => '41923, 42992',
+            'table_with_range_limit' => [41923, 42992],
+            'table_with_invalid_range_limit' => [41923],
+            'table_with_invalid_range_limit2' => [41923, 42992, 42999],
         ]);
 
         $this->assertEquals(200, $dump->getTableLimit('users'));
         $this->assertEquals(500, $dump->getTableLimit('logs'));
         $this->assertFalse($dump->getTableLimit('table_with_invalid_limit'));
         $this->assertFalse($dump->getTableLimit('table_name_with_no_limit'));
+        $this->assertEquals('41923, 42992', $dump->getTableLimit('table_with_range_limit'));
+        $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit'));
+        $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit2'));
     }
 }


### PR DESCRIPTION
I added support for offset in table limit
sample usage:
`
$dump->setTableLimits([
                'table_name' => [10,200],
            ]);
`

I think this may also be useful for other users. There have been several requests over the years to add this functionality.