### PR TITLE
Update deprecated GHA runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,50 +18,63 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            database-version: 'mysql:5.7'
+            database: 'mysql'
+            database-version: '5.7'
             php-version: '7.4'
           - os: ubuntu-20.04
-            database-version: 'mysql:5.7'
+            database: 'mysql'
+            database-version: '5.7'
             php-version: '8.0'
           - os: ubuntu-20.04
-            database-version: 'mysql:5.7'
+            database: 'mysql'
+            database-version: '5.7'
             php-version: '8.1'
           - os: ubuntu-20.04
-            database-version: 'mysql:5.7'
+            database: 'mysql'
+            database-version: '5.7'
             php-version: '8.2'
           - os: ubuntu-latest
-            database-version: 'mysql:8.0'
+            database: 'mysql'
+            database-version: '8.0'
             php-version: '7.4'
           - os: ubuntu-latest
-            database-version: 'mysql:8.0'
+            database: 'mysql'
+            database-version: '8.0'
             php-version: '8.0'
           - os: ubuntu-latest
-            database-version: 'mysql:8.0'
+            database: 'mysql'
+            database-version: '8.0'
             php-version: '8.1'
           - os: ubuntu-latest
-            database-version: 'mysql:8.0'
+            database: 'mysql'
+            database-version: '8.0'
             php-version: '8.2'
           - os: ubuntu-20.04
-            database-version: 'mariadb:10.6'
+            database: 'mariadb'
+            database-version: '10.6'
             php-version: '7.4'
           - os: ubuntu-20.04
-            database-version: 'mariadb:10.6'
+            database: 'mariadb'
+            database-version: '10.6'
             php-version: '8.0'
           - os: ubuntu-20.04
-            database-version: 'mariadb:10.6'
+            database: 'mariadb'
+            database-version: '10.6'
             php-version: '8.1'
           - os: ubuntu-20.04
-            database-version: 'mariadb:10.6'
+            database: 'mariadb'
+            database-version: '10.6'
             php-version: '8.2'
-
-    services:
-      db:
-        image: druidfi/${{ matrix.database-version }}-drupal
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
+
+      - uses: shogo82148/actions-setup-mysql@v1
+        with:
+          distribution: '${{ matrix.database }}'
+          mysql-version: '${{ matrix.database-version }}'
+          user: 'travis'
+          password: ''
+          root-password: 'drupal'
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mysql:5.7'
             php-version: '7.4'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mysql:5.7'
             php-version: '8.0'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mysql:5.7'
             php-version: '8.1'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mysql:5.7'
             php-version: '8.2'
           - os: ubuntu-latest
@@ -41,16 +41,16 @@ jobs:
           - os: ubuntu-latest
             database-version: 'mysql:8.0'
             php-version: '8.2'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mariadb:10.6'
             php-version: '7.4'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mariadb:10.6'
             php-version: '8.0'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mariadb:10.6'
             php-version: '8.1'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             database-version: 'mariadb:10.6'
             php-version: '8.2'
 


### PR DESCRIPTION
Ubuntu 18.04 runner is removed. See https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/