### PR TITLE
Inline escape() method to improve performance

### DIFF
--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -767,19 +767,23 @@ class Mysqldump
             if ($this->transformColumnValueCallable) {
                 $colValue = call_user_func($this->transformColumnValueCallable, $tableName, $colName, $colValue, $row);
             }
-            $colType = $columnTypes[$colName];
 
             if ($colValue === null) {
                 $ret[] = "NULL";
                 continue;
-            } elseif ($hexBlobEnabled && $colType['is_blob']) {
+            }
+
+            $colType = $columnTypes[$colName];
+            if ($hexBlobEnabled && $colType['is_blob']) {
                 if ($colType['type'] == 'bit' || $colValue !== '') {
                     $ret[] = sprintf('0x%s', $colValue);
                 } else {
                     $ret[] = "''";
                 }
                 continue;
-            } elseif ($colType['is_numeric']) {
+            }
+
+            if ($colType['is_numeric']) {
                 $ret[] = $colValue;
                 continue;
             }

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -773,7 +773,7 @@ class Mysqldump
                 $ret[] = "NULL";
                 continue;
             } elseif ($hexBlobEnabled && $colType['is_blob']) {
-                if ($colType['type'] == 'bit' || !empty($colValue)) {
+                if ($colType['type'] == 'bit' || $colValue !== '') {
                     $ret[] = sprintf('0x%s', $colValue);
                 } else {
                     $ret[] = "''";

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -762,6 +762,7 @@ class Mysqldump
         }
 
         $dbHandler = $this->conn;
+        $hexBlobEnabled = $this->settings->isEnabled('hex-blob');
         foreach ($row as $colName => $colValue) {
             if ($this->transformColumnValueCallable) {
                 $colValue = call_user_func($this->transformColumnValueCallable, $tableName, $colName, $colValue, $row);
@@ -771,7 +772,7 @@ class Mysqldump
             if ($colValue === null) {
                 $ret[] = "NULL";
                 continue;
-            } elseif ($this->settings->isEnabled('hex-blob') && $colType['is_blob']) {
+            } elseif ($hexBlobEnabled && $colType['is_blob']) {
                 if ($colType['type'] == 'bit' || !empty($colValue)) {
                     $ret[] = sprintf('0x%s', $colValue);
                 } else {


### PR DESCRIPTION
dumping a InnoDB table containing  1,4 GiB  of data ...

```php
<?php // test.php

error_reporting(E_ALL);

require_once __DIR__ . '/vendor/autoload.php';

use Druidfi\Mysqldump as IMysqldump;

$date = date('Ymd');
$dumpSettings = array(
    'no-data' => false,
    'add-drop-table' => true,
    'single-transaction' => true,
    'lock-tables' => false,
    'add-locks' => true,
    'extended-insert' => true,
    'disable-foreign-keys-check' => true,
    'skip-triggers' => false,
    'add-drop-trigger' => true,
    'databases' => true,
    'add-drop-database' => true,
    'hex-blob' => true,
    'include-tables' => array('my-table'), // add a table name here
);

$dump = new IMysqldump\Mysqldump("mysql:host=$hostname;dbname=$db", $username, $password, $dumpSettings); // add DB credentials
$dump->start("backup$date.sql");
```


before this change
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m41.353s
user    0m30.015s
sys     0m7.903s
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m43.333s
user    0m31.603s
sys     0m8.279s
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php
```

after this change
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m37.625s
user    0m26.760s
sys     0m7.848s

mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m37.937s
user    0m26.506s
sys     0m8.259s
```

the improvement works, because the `escape` method is called for every column in every row, so the method call overhead is visible

![grafik](https://github.com/ifsnop/mysqldump-php/assets/120441/9cbd849c-491f-4f3f-bd1d-74052b8c170d)



### PHP Version

PHP 8.1.27

### Operating System

ubuntu 22 lts