### PR TITLE
Trigger the dump info hook when max buffer length is reached

### DIFF
--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -835,6 +835,11 @@ class Mysqldump
         $ignore = $this->settings->isEnabled('insert-ignore') ? '  IGNORE' : '';
         $count = 0;
 
+        $isInfoCallable = $this->infoCallable && is_callable($this->infoCallable);
+        if ($isInfoCallable) {
+            ($this->infoCallable)('table', ['name' => $tableName, 'completed' => false, 'rowCount' => $count]);
+        }
+
         $line = '';
         foreach ($resultSet as $row) {
             $count++;
@@ -863,6 +868,10 @@ class Mysqldump
                 $onlyOnce = true;
                 $this->write($line . ';' . PHP_EOL);
                 $line = '';
+
+                if ($isInfoCallable) {
+                    ($this->infoCallable)('table', ['name' => $tableName, 'completed' => false, 'rowCount' => $count]);
+                }
             }
         }
 
@@ -874,8 +883,8 @@ class Mysqldump
 
         $this->endListValues($tableName, $count);
 
-        if ($this->infoCallable && is_callable($this->infoCallable)) {
-            ($this->infoCallable)('table', ['name' => $tableName, 'rowCount' => $count]);
+        if ($isInfoCallable) {
+            ($this->infoCallable)('table', ['name' => $tableName, 'completed' => true, 'rowCount' => $count]);
         }
 
         $this->settings->setCompleteInsert($completeInsertBackup);


### PR DESCRIPTION
This PR adds two situations where the info hook is triggered:

- Before data is being written to a table
- When data is written to a table (max net buffer length reached)

As discussed in PR #38 and issue #39, this change would allow to periodically report the dump progress for very big tables.

Fixes #39 