### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Run tests
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Run tests
+
 permissions:
-  contents: read
+  contents: read # For reading the repository
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/druidfi/mysqldump-php/security/code-scanning/1](https://github.com/druidfi/mysqldump-php/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's operations, it primarily needs `contents: read` to check out the code and validate dependencies. No write permissions are required.

The `permissions` block will be added at the top of the file, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
