### PR TITLE
Create a separate DatabaseConnector class to handle connection logic

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -5,7 +5,7 @@ This document contains a detailed list of actionable improvement tasks for the m
 ## Architecture Improvements
 
 1. [ ] Refactor the large Mysqldump class into smaller, more focused classes:
-   - [ ] Create a separate DatabaseConnector class to handle connection logic
+   - [x] Create a separate DatabaseConnector class to handle connection logic
    - [ ] Create a separate DumpWriter class to handle file output
    - [ ] Create separate classes for different database object types (Tables, Views, Triggers, etc.)
 

--- a/src/DatabaseConnector.php
+++ b/src/DatabaseConnector.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Druidfi\Mysqldump;
+
+use Exception;
+use PDO;
+use PDOException;
+
+/**
+ * Class DatabaseConnector
+ * 
+ * Handles database connection logic for mysqldump-php.
+ */
+class DatabaseConnector
+{
+    /**
+     * @var string DSN connection string
+     */
+    private string $dsn;
+
+    /**
+     * @var string|null Username for database connection
+     */
+    private ?string $user;
+
+    /**
+     * @var string|null Password for database connection
+     */
+    private ?string $pass;
+
+    /**
+     * @var array PDO options
+     */
+    private array $pdoOptions;
+
+    /**
+     * @var string Database host
+     */
+    private string $host;
+
+    /**
+     * @var string Database name
+     */
+    private string $dbName;
+
+    /**
+     * @var PDO|null PDO connection
+     */
+    private ?PDO $conn = null;
+
+    /**
+     * Constructor of DatabaseConnector.
+     *
+     * @param string $dsn PDO DSN connection string
+     * @param string|null $user SQL account username
+     * @param string|null $pass SQL account password
+     * @param array $pdoOptions PDO configured attributes
+     * @throws Exception
+     */
+    public function __construct(
+        string $dsn = '',
+        ?string $user = null,
+        ?string $pass = null,
+        array $pdoOptions = []
+    ) {
+        $this->dsn = $this->parseDsn($dsn);
+        $this->user = $user;
+        $this->pass = $pass;
+        $this->pdoOptions = $pdoOptions;
+    }
+
+    /**
+     * Parse DSN string and extract dbname value
+     * Several examples of a DSN string
+     *   mysql:host=localhost;dbname=testdb
+     *   mysql:host=localhost;port=3307;dbname=testdb
+     *   mysql:unix_socket=/tmp/mysql.sock;dbname=testdb
+     *
+     * @param string $dsn dsn string to parse
+     * @return string The parsed DSN
+     * @throws Exception
+     */
+    private function parseDsn(string $dsn): string
+    {
+        if (empty($dsn) || !($pos = strpos($dsn, ':'))) {
+            throw new Exception('Empty DSN string');
+        }
+
+        $dbType = strtolower(substr($dsn, 0, $pos));
+
+        if (empty($dbType)) {
+            throw new Exception('Missing database type from DSN string');
+        }
+
+        $data = [];
+
+        foreach (explode(';', substr($dsn, $pos + 1)) as $kvp) {
+            if (str_contains($kvp, '=')) {
+                list($param, $value) = explode('=', $kvp);
+                $data[trim(strtolower($param))] = $value;
+            }
+        }
+
+        if (empty($data['host']) && empty($data['unix_socket'])) {
+            throw new Exception('Missing host from DSN string');
+        }
+
+        if (empty($data['dbname'])) {
+            throw new Exception('Missing database name from DSN string');
+        }
+
+        $this->host = (!empty($data['host'])) ? $data['host'] : $data['unix_socket'];
+        $this->dbName = $data['dbname'];
+
+        return $dsn;
+    }
+
+    /**
+     * Connect to the database with PDO.
+     *
+     * @return PDO The PDO connection
+     * @throws Exception
+     */
+    public function connect(): PDO
+    {
+        if ($this->conn !== null) {
+            return $this->conn;
+        }
+
+        try {
+            $options = array_replace_recursive([
+                PDO::ATTR_PERSISTENT => true,
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                // Don't convert empty strings to SQL NULL values on data fetches.
+                PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
+                PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false,
+            ], $this->pdoOptions);
+
+            $this->conn = new PDO($this->dsn, $this->user, $this->pass, $options);
+        } catch (PDOException $e) {
+            $message = sprintf("Connection to %s failed with message: %s", $this->host, $e->getMessage());
+            throw new Exception($message);
+        }
+
+        return $this->conn;
+    }
+
+    /**
+     * Get the database host.
+     *
+     * @return string
+     */
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    /**
+     * Get the database name.
+     *
+     * @return string
+     */
+    public function getDbName(): string
+    {
+        return $this->dbName;
+    }
+}

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -44,11 +44,16 @@ class MysqldumpTest extends TestCase
         $dbName = 'test';
         $dsn = "mysql: host={$host}; dbname={$dbName};";
         $dump = new Mysqldump($dsn, $user, $pass);
-        $this->assertEquals($dsn, $this->getPrivate($dump, 'dsn'), 'dsn is not set correctly');
-        $this->assertEquals($user, $this->getPrivate($dump, 'user'), 'user is not set correctly');
-        $this->assertEquals($pass, $this->getPrivate($dump, 'pass'), 'pass is not set correctly');
-        $this->assertEquals($host, $this->getPrivate($dump, 'host'), 'host is not set correctly');
-        $this->assertEquals($dbName, $this->getPrivate($dump, 'dbName'), 'dbName is not set correctly');
+
+        // Get the connector property
+        $connector = $this->getPrivate($dump, 'connector');
+
+        // Test the properties on the connector
+        $this->assertEquals($dsn, $this->getPrivateFromObject($connector, 'dsn'), 'dsn is not set correctly');
+        $this->assertEquals($user, $this->getPrivateFromObject($connector, 'user'), 'user is not set correctly');
+        $this->assertEquals($pass, $this->getPrivateFromObject($connector, 'pass'), 'pass is not set correctly');
+        $this->assertEquals($host, $this->getPrivateFromObject($connector, 'host'), 'host is not set correctly');
+        $this->assertEquals($dbName, $this->getPrivateFromObject($connector, 'dbName'), 'dbName is not set correctly');
     }
 
   /**
@@ -120,5 +125,12 @@ class MysqldumpTest extends TestCase
         $reflectionProperty = new \ReflectionProperty(Mysqldump::class, $var);
         $reflectionProperty->setAccessible(true);
         return $reflectionProperty->getValue($dump);
+    }
+
+    private function getPrivateFromObject($object, $var)
+    {
+        $reflectionProperty = new \ReflectionProperty(get_class($object), $var);
+        $reflectionProperty->setAccessible(true);
+        return $reflectionProperty->getValue($object);
     }
 }


### PR DESCRIPTION
This pull request introduces a significant refactoring to the `Mysqldump` class by extracting database connection logic into a new `DatabaseConnector` class. This change improves modularity and maintainability while simplifying the `Mysqldump` class. Additionally, the tests were updated to reflect these changes. Below is a summary of the most important changes:

### Refactoring and Modularization
* Created a new `DatabaseConnector` class in `src/DatabaseConnector.php` to handle database connection logic, including parsing the DSN, managing connection credentials, and establishing a PDO connection. (`[src/DatabaseConnector.phpR1-R167](diffhunk://#diff-8d8a1345859354a5a3b2d269d53fad121d8134ad7d6d984b41032d076c6059ccR1-R167)`)
* Replaced the connection-related properties and methods in `Mysqldump` with a single `DatabaseConnector` instance. The constructor and methods like `connect` now delegate connection responsibilities to the `DatabaseConnector`. (`[[1]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L24-R29)`, `[[2]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L80-R92)`)

### Updates to `Mysqldump` Class
* Replaced direct usage of `dsn`, `host`, and `dbName` in multiple methods with calls to the corresponding getter methods in `DatabaseConnector`. This ensures encapsulation and reduces redundancy. (`[[1]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L209-R145)`, `[[2]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L225-R158)`, `[[3]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L271-R205)`, `[[4]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L312-R250)`, `[[5]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L338-R276)`, `[[6]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L360-R293)`, `[[7]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L373-R306)`, `[[8]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L386-R319)`, `[[9]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L399-R332)`, `[[10]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L691-R624)`, `[[11]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L714-R647)`, `[[12]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L738-R671)`)

### Documentation Updates
* Marked the task of creating the `DatabaseConnector` class as completed in `docs/tasks.md`. (`[docs/tasks.mdL8-R8](diffhunk://#diff-32b9ce4e0753829f99ab158f85b9e5b6fbb11655d596c37cf900152f83b854c4L8-R8)`)

### Test Updates
* Updated the test `testDSNWorks` in `tests/MysqldumpTest.php` to validate the properties of the `DatabaseConnector` instead of the `Mysqldump` class directly. (`[tests/MysqldumpTest.phpL47-R56](diffhunk://#diff-25bf7e0c8e9caae034820ad5118f9e80cadf0ab8383ce8568f3d98e0685872bfL47-R56)`)
* Added a helper method `getPrivateFromObject` in `tests/MysqldumpTest.php` to access private properties of the `DatabaseConnector` during testing. (`[tests/MysqldumpTest.phpR129-R135](diffhunk://#diff-25bf7e0c8e9caae034820ad5118f9e80cadf0ab8383ce8568f3d98e0685872bfR129-R135)`)