### PR TITLE
Fix issue #35

### DIFF
--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -1040,4 +1040,12 @@ class Mysqldump
     {
         $this->infoCallable = $callable;
     }
+
+    /**
+     * Set a callable that will be used to transform column values.
+     */
+    public function setTransformColumnValueHook(callable $callable)
+    {
+        $this->transformColumnValueCallable = $callable;
+    }
 }


### PR DESCRIPTION
Create a public method `setTransformColumnValueHook` so that private property `$transformColumnValueCallable` can be set.

Variable itself is used here: https://github.com/druidfi/mysqldump-php/blob/main/src/Mysqldump.php#L703

Will resolve #35 