### PR TITLE
Create a separate DumpWriter class to handle file output

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -6,7 +6,7 @@ This document contains a detailed list of actionable improvement tasks for the m
 
 1. [ ] Refactor the large Mysqldump class into smaller, more focused classes:
    - [x] Create a separate DatabaseConnector class to handle connection logic
-   - [ ] Create a separate DumpWriter class to handle file output
+   - [x] Create a separate DumpWriter class to handle file output
    - [ ] Create separate classes for different database object types (Tables, Views, Triggers, etc.)
 
 2. [ ] Implement a proper dependency injection system:

--- a/src/DumpWriter.php
+++ b/src/DumpWriter.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Druidfi\Mysqldump;
+
+use Druidfi\Mysqldump\Compress\CompressInterface;
+use Druidfi\Mysqldump\Compress\CompressManagerFactory;
+use Exception;
+
+/**
+ * Class DumpWriter
+ * 
+ * Handles file output operations for mysqldump-php.
+ */
+class DumpWriter
+{
+    /**
+     * @var CompressInterface Compression manager
+     */
+    private CompressInterface $io;
+
+    /**
+     * @var DumpSettings Settings for the dump
+     */
+    private DumpSettings $settings;
+
+    /**
+     * Constructor of DumpWriter.
+     *
+     * @param DumpSettings $settings Settings for the dump
+     */
+    public function __construct(DumpSettings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Initialize the writer with the specified destination.
+     *
+     * @param string $destination Path to the output file or php://stdout
+     * @throws Exception
+     */
+    public function initialize(string $destination): void
+    {
+        // Create a new compressManager to manage compressed output
+        $this->io = CompressManagerFactory::create(
+            $this->settings->getCompressMethod(),
+            $this->settings->getCompressLevel()
+        );
+
+        // Create output file
+        $this->io->open($destination);
+    }
+
+    /**
+     * Write data to the output file.
+     *
+     * @param string $data Data to write
+     * @return int Number of bytes written
+     * @throws Exception
+     */
+    public function write(string $data): int
+    {
+        return $this->io->write($data);
+    }
+
+    /**
+     * Close the output file.
+     *
+     * @return bool True on success
+     */
+    public function close(): bool
+    {
+        return $this->io->close();
+    }
+}


### PR DESCRIPTION
This pull request introduces a significant refactor to the `Mysqldump` class by extracting file output operations into a new `DumpWriter` class. This change improves code modularity and maintainability. The key updates include the creation and integration of the `DumpWriter` class, adjustments to the `Mysqldump` class to use this new class, and corresponding updates to documentation.

### Refactor of `Mysqldump` class:

* **Creation of `DumpWriter` class**:
  - A new `DumpWriter` class has been implemented to handle file output operations, including initialization, writing, and closing. This class uses a compression manager to manage compressed output. (`src/DumpWriter.php`, [src/DumpWriter.phpR1-R75](diffhunk://#diff-32b79a1917c5d63c4dc0cd6d6aeea98573b5a033a1539ab9609d6613b44f688fR1-R75))

* **Integration of `DumpWriter` into `Mysqldump`**:
  - The `Mysqldump` class now uses the `DumpWriter` class instead of managing file output directly. This includes replacing the `CompressInterface` property with a `DumpWriter` property, updating the constructor to instantiate `DumpWriter`, and modifying methods to delegate file operations to `DumpWriter`. (`src/Mysqldump.php`, [[1]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L30-R28) [[2]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797R74) [[3]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L97-R96) [[4]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L118-R118) [[5]](diffhunk://#diff-e71f925f9341c8e36b05e0df42357f8d8dd74809661911dde841866d41f04797L190-R183)

### Documentation updates:

* **Task completion**:
  - Marked the task "Create a separate DumpWriter class to handle file output" as completed in the `docs/tasks.md` file.