### PR TITLE
PHP 8.1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,10 @@ jobs:
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnami/mysql:8.0
+            php-version: 8.1
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnami/mysql:8.0
             php-version: 8.2
           - os: ubuntu-24.04
             database: mysql
@@ -60,6 +64,10 @@ jobs:
             php-version: 8.5
 
           # MariaDB 10.11 LTS
+          - os: ubuntu-22.04
+            database: mariadb
+            database_image: bitnami/mariadb:10.11
+            php-version: 8.1
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnami/mariadb:10.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG PHP_SHORT_VERSION=82
 
+FROM php:8.1 AS php-81
 FROM php:8.2 AS php-82
 FROM php:8.3 AS php-83
 FROM php:8.4 AS php-84

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Out of the box, `mysqldump-php` supports backing up table structures, the data i
 
 ## Requirements
 
-- PHP 8.2 or newer with PDO - [see supported versions](https://www.php.net/supported-versions.php)
+- PHP 8.1 or newer with PDO - [see supported versions](https://www.php.net/supported-versions.php)
 - MySQL 8.0 or newer (and compatible MariaDB)
 
 ## Installing
@@ -246,10 +246,12 @@ Local setup for tests:
 ```console
 composer install
 docker compose up --wait --build
+docker compose exec -w /app/tests/scripts php81 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php82 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php83 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php84 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php85 ./test.sh mysql
+docker compose exec -w /app/tests/scripts php81 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php82 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php83 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php84 ./test.sh mariadb

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,19 @@ services:
     volumes:
       - ./docker-entrypoint-initdb.d/mariadb-init.sql:/docker-entrypoint-initdb.d/00-init.sql
 
+  php81:
+    container_name: mysqldump-php-81
+    build:
+      context: .
+      args:
+        PHP_SHORT_VERSION: 81
+    volumes:
+      - .:/app
+      - ./config/skip-ssl.cnf:/etc/my.cnf.d/skip-ssl.cnf
+    depends_on:
+      - mysql
+      - mariadb
+
   php82:
     container_name: mysqldump-php-82
     build:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "composer-runtime-api": "^2",
         "ext-pdo": "*"
     },


### PR DESCRIPTION
PHP 8.1 is still supported version until the end of 2025