### PR TITLE
Fix compress-level setting ignored in CompressGzip

### DIFF
--- a/src/Compress/CompressGzip.php
+++ b/src/Compress/CompressGzip.php
@@ -7,15 +7,19 @@ use Exception;
 class CompressGzip implements CompressInterface
 {
     private $fileHandler;
+    private int $level;
 
     /**
      * @throws Exception
      */
-    public function __construct()
+    public function __construct(int $level = 0)
     {
         if (!function_exists('gzopen')) {
             throw new Exception('Compression is enabled, but gzip lib is not installed or configured properly');
         }
+
+        // gzip level: 0 = default, 1-9 = fast to best
+        $this->level = ($level >= 1 && $level <= 9) ? $level : 0;
     }
 
     /**
@@ -23,7 +27,8 @@ class CompressGzip implements CompressInterface
      */
     public function open(string $filename): bool
     {
-        $this->fileHandler = gzopen($filename, 'wb');
+        $mode = $this->level > 0 ? 'wb' . $this->level : 'wb';
+        $this->fileHandler = gzopen($filename, $mode);
 
         if (false === $this->fileHandler) {
             throw new Exception('Output file is not writable');

--- a/src/Compress/CompressManagerFactory.php
+++ b/src/Compress/CompressManagerFactory.php
@@ -37,9 +37,7 @@ abstract class CompressManagerFactory
         $methodClass = __NAMESPACE__."\\"."Compress".$method;
 
         // Pass compression level to the constructor if the method supports it
-        if ($method === self::ZSTD && $level > 0) {
-            return new $methodClass($level);
-        } elseif ($method === self::LZ4 && $level > 0) {
+        if (in_array($method, [self::GZIP, self::ZSTD, self::LZ4], true) && $level > 0) {
             return new $methodClass($level);
         }
 

--- a/tests/CompressGzipTest.php
+++ b/tests/CompressGzipTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump\Tests;
+
+use Druidfi\Mysqldump\Compress\CompressGzip;
+use Druidfi\Mysqldump\Compress\CompressManagerFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Druidfi\Mysqldump\Compress\CompressGzip
+ */
+class CompressGzipTest extends TestCase
+{
+    public function testDefaultLevelIsZero(): void
+    {
+        $gzip = new CompressGzip();
+        $this->assertSame(0, $this->getLevel($gzip));
+    }
+
+    /**
+     * @dataProvider validLevelProvider
+     */
+    public function testValidLevelIsStored(int $level): void
+    {
+        $gzip = new CompressGzip($level);
+        $this->assertSame($level, $this->getLevel($gzip));
+    }
+
+    public static function validLevelProvider(): array
+    {
+        return [[1], [5], [9]];
+    }
+
+    /**
+     * @dataProvider outOfRangeLevelProvider
+     */
+    public function testOutOfRangeLevelFallsBackToDefault(int $level): void
+    {
+        $gzip = new CompressGzip($level);
+        $this->assertSame(0, $this->getLevel($gzip));
+    }
+
+    public static function outOfRangeLevelProvider(): array
+    {
+        return [[0], [10], [100]];
+    }
+
+    public function testFactoryPassesLevelToGzip(): void
+    {
+        $gzip = CompressManagerFactory::create(CompressManagerFactory::GZIP, 7);
+        $this->assertSame(7, $this->getLevel($gzip));
+    }
+
+    public function testFactoryWithDefaultLevelCreatesGzipWithLevelZero(): void
+    {
+        $gzip = CompressManagerFactory::create(CompressManagerFactory::GZIP);
+        $this->assertSame(0, $this->getLevel($gzip));
+    }
+
+    public function testWriteAndReadWithLevel(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'mysqldump_test_') . '.gz';
+
+        try {
+            $gzip = new CompressGzip(1);
+            $gzip->open($tmpFile);
+            $gzip->write('test data');
+            $gzip->close();
+
+            $this->assertFileExists($tmpFile);
+            $this->assertGreaterThan(0, filesize($tmpFile));
+
+            // Verify the file is valid gzip by reading it back
+            $handle = gzopen($tmpFile, 'rb');
+            $this->assertNotFalse($handle);
+            $content = gzread($handle, 1024);
+            gzclose($handle);
+            $this->assertSame('test data', $content);
+        } finally {
+            if (file_exists($tmpFile)) {
+                unlink($tmpFile);
+            }
+        }
+    }
+
+    private function getLevel(CompressGzip $gzip): int
+    {
+        $ref = new \ReflectionProperty(CompressGzip::class, 'level');
+        $ref->setAccessible(true);
+        return $ref->getValue($gzip);
+    }
+}


### PR DESCRIPTION
## Summary

- `CompressGzip` hardcoded `'wb'` as the `gzopen` mode, ignoring the `compress-level` setting entirely
- `CompressManagerFactory` only forwarded `$level` to `Zstd` and `Lz4` constructors, not `Gzip`
- `CompressGzip` now accepts `int $level = 0` in its constructor and appends it to the mode string (`'wb1'`–`'wb9'`) when a valid level (1–9) is provided
- `CompressManagerFactory` now passes `$level` to Gzip alongside Zstd and Lz4

Closes #76

## Test plan

- [x] Dump with `'compress' => 'Gzip', 'compress-level' => 1`: verify faster/larger output vs default level
- [x] Dump with `'compress' => 'Gzip', 'compress-level' => 9`: verify slower/smaller output vs default
- [x] Dump with no `compress-level` set: verify default behavior unchanged (`'wb'` mode)
- [x] Run `vendor/bin/phpunit`
- [x] CI: all 10 matrix jobs passed (PHP 8.1–8.5 × MySQL 8.0 + MariaDB 10.11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)