### PR TITLE
Update PHPUnit to ^10.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /tests/scripts/output/*.sql
 /vendor/
 /.phpunit.result.cache
+/.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^10.5",
         "rector/rector": "^2.3"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" forceCoversAnnotation="true" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" verbose="true">
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/CompressGzipTest.php
+++ b/tests/CompressGzipTest.php
@@ -6,11 +6,11 @@ namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\Compress\CompressGzip;
 use Druidfi\Mysqldump\Compress\CompressManagerFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Druidfi\Mysqldump\Compress\CompressGzip
- */
+#[CoversClass(CompressGzip::class)]
 class CompressGzipTest extends TestCase
 {
     public function testDefaultLevelIsZero(): void
@@ -19,9 +19,7 @@ class CompressGzipTest extends TestCase
         $this->assertSame(0, $this->getLevel($gzip));
     }
 
-    /**
-     * @dataProvider validLevelProvider
-     */
+    #[DataProvider('validLevelProvider')]
     public function testValidLevelIsStored(int $level): void
     {
         $gzip = new CompressGzip($level);
@@ -33,9 +31,7 @@ class CompressGzipTest extends TestCase
         return [[1], [5], [9]];
     }
 
-    /**
-     * @dataProvider outOfRangeLevelProvider
-     */
+    #[DataProvider('outOfRangeLevelProvider')]
     public function testOutOfRangeLevelFallsBackToDefault(int $level): void
     {
         $gzip = new CompressGzip($level);

--- a/tests/CompressManagerFactoryTest.php
+++ b/tests/CompressManagerFactoryTest.php
@@ -3,12 +3,11 @@
 namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\Compress\CompressManagerFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Exception;
 
-/**
- * @covers \Druidfi\Mysqldump\Compress\CompressManagerFactory
- */
+#[CoversClass(CompressManagerFactory::class)]
 class CompressManagerFactoryTest extends TestCase
 {
     public function testCreateCommonMethods()

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -5,12 +5,14 @@ namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\ConfigValidator;
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Tests that ConfigValidator properly reads and uses PHP Attributes
  * from ConfigOption class for validation and deprecation checking.
  */
+#[CoversClass(ConfigValidator::class)]
 class ConfigValidatorTest extends TestCase
 {
     public function testGetDefaultsReturnsAttributeValues(): void

--- a/tests/DatabaseConnectorTest.php
+++ b/tests/DatabaseConnectorTest.php
@@ -3,12 +3,11 @@
 namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\DatabaseConnector;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Exception;
 
-/**
- * @covers \Druidfi\Mysqldump\DatabaseConnector
- */
+#[CoversClass(DatabaseConnector::class)]
 class DatabaseConnectorTest extends TestCase
 {
     public function testParseDsnValidHostAndDbname()

--- a/tests/DumpSettingsTest.php
+++ b/tests/DumpSettingsTest.php
@@ -3,12 +3,11 @@
 namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\DumpSettings;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Exception;
 
-/**
- * @covers \Druidfi\Mysqldump\DumpSettings
- */
+#[CoversClass(DumpSettings::class)]
 class DumpSettingsTest extends TestCase
 {
     /**

--- a/tests/MysqldumpAdapterTest.php
+++ b/tests/MysqldumpAdapterTest.php
@@ -4,13 +4,12 @@ namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\Mysqldump;
 use Druidfi\Mysqldump\Tests\Doubles\FakeTypeAdapter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Exception;
 use PDO;
 
-/**
- * @covers \Druidfi\Mysqldump
- */
+#[CoversClass(Mysqldump::class)]
 class MysqldumpAdapterTest extends TestCase
 {
     public function testAddTypeAdapterRejectsInvalidClass()

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -3,13 +3,12 @@
 namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\Mysqldump;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Mysqldump::class)]
 class MysqldumpTest extends TestCase
 {
-    /**
-     * @covers Mysqldump
-     */
     public function testTableSpecificWhereConditionsWork()
     {
         $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'testing', 'testing', [
@@ -33,9 +32,6 @@ class MysqldumpTest extends TestCase
         );
     }
 
-    /**
-     * @covers Mysqldump
-     */
     public function testDSNWorks()
     {
         $user = 'user';
@@ -56,45 +52,30 @@ class MysqldumpTest extends TestCase
         $this->assertEquals($dbName, $this->getPrivateFromObject($connector, 'dbName'), 'dbName is not set correctly');
     }
 
-  /**
-     * @covers Mysqldump
-     */
     public function testDSNStringExits()
     {
         $this->expectException(\Exception::class);
         $dump = new Mysqldump('', 'testing', 'testing');
     }
 
-    /**
-     * @covers Mysqldump
-     */
     public function testHostExits()
     {
         $this->expectException(\Exception::class);
         $dump = new Mysqldump('mysql: dbname=test;', 'testing', 'testing');
     }
 
-    /**
-     * @covers Mysqldump
-     */
     public function testDBTypeExists()
     {
         $this->expectException(\Exception::class);
         $dump = new Mysqldump('host=localhost; dbname=test;', 'testing', 'testing');
     }
 
-    /**
-     * @covers Mysqldump
-     */
     public function testDBNameExists()
     {
         $this->expectException(\Exception::class);
         $dump = new Mysqldump('mysql: host=localhost', 'testing', 'testing');
     }
 
-    /**
-     * @covers Mysqldump
-     */
     public function testTableSpecificLimitsWork()
     {
         $dump = new Mysqldump('mysql: host=localhost; dbname=test;', 'testing', 'testing');

--- a/tests/ReplaceTest.php
+++ b/tests/ReplaceTest.php
@@ -4,13 +4,12 @@ namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\DumpSettings;
 use Druidfi\Mysqldump\Mysqldump;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Exception;
 
-/**
- * @covers \Druidfi\Mysqldump\Mysqldump
- * @covers \Druidfi\Mysqldump\DumpSettings
- */
+#[CoversClass(Mysqldump::class)]
+#[CoversClass(DumpSettings::class)]
 class ReplaceTest extends TestCase
 {
     /**


### PR DESCRIPTION
## Summary

Upgrades PHPUnit from `^9` to `^10.5`. PHPUnit 10 supports PHP >= 8.1, so the full CI matrix (PHP 8.1–8.5 x MySQL 8.0 / MariaDB 10.11) is unaffected. PHPUnit 11 was deliberately skipped as it requires PHP >= 8.2 and would drop PHP 8.1 support.

## Changes

- **composer.json**: `phpunit/phpunit` `^9` → `^10.5`
- **phpunit.xml**: migrated to the 10.5 schema via `--migrate-configuration` (`forceCoversAnnotation` → `requireCoverageMetadata`, coverage `<include>` → `<source>`, removed `verbose`/`processUncoveredFiles`)
- **tests**: converted `@covers` / `@dataProvider` docblock annotations to `#[CoversClass]` / `#[DataProvider]` attributes (annotations are deprecated in 10 and removed in PHPUnit 12; attributes also match this codebase's PHP 8 attribute conventions)
  - Fixed non-namespaced `@covers Mysqldump` in `MysqldumpTest` and namespace-only `@covers \Druidfi\Mysqldump` in `MysqldumpAdapterTest`
  - Added missing coverage metadata to `ConfigValidatorTest` (required by `requireCoverageMetadata`)
- **.gitignore**: added PHPUnit 10's `.phpunit.cache/` directory

Data providers were already static, as PHPUnit 10 requires.

## Test plan

- [x] `vendor/bin/phpunit` — 60 tests, 143 assertions, OK on PHPUnit 10.5.63 with no deprecation warnings
- [x] `vendor/bin/rector process --dry-run` — clean
- [x] `vendor/bin/phpstan` — same 4 pre-existing findings as on main, nothing new introduced
- [x] Full CI matrix (PHP 8.1–8.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)