### PR TITLE
Fix PHPStan findings and update actions/checkout to v7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,6 @@ jobs:
 
       - name: Run PHPStan
         run: vendor/bin/phpstan --error-format=github --no-progress --ansi
-        continue-on-error: true
 
       - name: Run PHPunit tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}

--- a/tests/CompressManagerFactoryTest.php
+++ b/tests/CompressManagerFactoryTest.php
@@ -2,7 +2,11 @@
 
 namespace Druidfi\Mysqldump\Tests;
 
+use Druidfi\Mysqldump\Compress\CompressBzip2;
+use Druidfi\Mysqldump\Compress\CompressGzip;
+use Druidfi\Mysqldump\Compress\CompressGzipstream;
 use Druidfi\Mysqldump\Compress\CompressManagerFactory;
+use Druidfi\Mysqldump\Compress\CompressNone;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Exception;
@@ -14,16 +18,16 @@ class CompressManagerFactoryTest extends TestCase
     {
         // Test only methods that don't require uncommon extensions
         $common = [
-            CompressManagerFactory::NONE,
-            CompressManagerFactory::GZIP,
-            CompressManagerFactory::BZIP2,
-            CompressManagerFactory::GZIPSTREAM,
+            CompressManagerFactory::NONE => CompressNone::class,
+            CompressManagerFactory::GZIP => CompressGzip::class,
+            CompressManagerFactory::BZIP2 => CompressBzip2::class,
+            CompressManagerFactory::GZIPSTREAM => CompressGzipstream::class,
         ];
 
-        foreach ($common as $method) {
+        foreach ($common as $method => $expectedClass) {
             try {
                 $instance = CompressManagerFactory::create($method, 3);
-                $this->assertIsObject($instance, "Factory did not return object for $method");
+                $this->assertInstanceOf($expectedClass, $instance, "Factory did not return $expectedClass for $method");
             } catch (Exception $e) {
                 // If environment lacks required functions, skip gracefully
                 $this->markTestSkipped("Skipping $method due to missing extension: {$e->getMessage()}");

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -20,7 +20,6 @@ class ConfigValidatorTest extends TestCase
         $defaults = ConfigValidator::getDefaults();
 
         // Check that defaults are loaded from DefaultValue attributes
-        $this->assertIsArray($defaults);
         $this->assertArrayHasKey('compress', $defaults);
         $this->assertEquals('None', $defaults['compress']);
         $this->assertArrayHasKey('compress-level', $defaults);

--- a/tests/Doubles/FakeTypeAdapter.php
+++ b/tests/Doubles/FakeTypeAdapter.php
@@ -8,9 +8,10 @@ use PDO;
 
 class FakeTypeAdapter implements TypeAdapterInterface
 {
-    public function __construct(PDO $conn, DumpSettings $settings)
-    {
-        // Do nothing; test double
+    public function __construct(
+        public readonly PDO $conn,
+        public readonly DumpSettings $settings,
+    ) {
     }
 
     public function addDropDatabase(string $databaseName): string { return ''; }

--- a/tests/MysqldumpAdapterTest.php
+++ b/tests/MysqldumpAdapterTest.php
@@ -27,6 +27,7 @@ class MysqldumpAdapterTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $adapter = $dump->getAdapter($pdo);
         $this->assertInstanceOf(FakeTypeAdapter::class, $adapter);
+        $this->assertSame($pdo, $adapter->conn);
     }
 
     public function testGetTableWhereReturnsFalseWhenUnset()


### PR DESCRIPTION
## Summary

Cleans up the 4 pre-existing PHPStan findings that annotate every CI run, bumps `actions/checkout` to v7 (latest) to silence the Node 20 deprecation warning, and makes PHPStan a blocking CI check now that it passes with zero errors.

## Changes

- **FakeTypeAdapter**: constructor parameters promoted to `public readonly` properties. The `(PDO, DumpSettings)` signature is required because `Mysqldump::getAdapter()` instantiates adapters with those arguments, so the parameters can't be dropped — now they're stored and usable by tests instead of ignored.
- **MysqldumpAdapterTest**: asserts the adapter received the exact PDO instance passed to `getAdapter()`, using the new property.
- **CompressManagerFactoryTest**: replaced the always-true `assertIsObject()` with `assertInstanceOf()` against the concrete class expected for each compression method (None → CompressNone, Gzip → CompressGzip, etc.) — a strictly stronger assertion.
- **ConfigValidatorTest**: removed the redundant `assertIsArray()` on a return value already typed as `array`.
- **tests.yml**: `actions/checkout@v4` → `@v7` (v4 targets Node 20, which GitHub runners have deprecated).
- **tests.yml**: removed `continue-on-error: true` from the PHPStan step — future findings will now fail the build instead of hiding in annotations.

## Test plan

- [x] `vendor/bin/phpstan` — 0 errors (was 4)
- [x] `vendor/bin/phpunit` — 60 tests, 143 assertions, OK
- [x] `vendor/bin/rector process --dry-run` — clean
- [x] CI matrix green with no annotations (run 28579465588)
- [x] CI still green with PHPStan as a blocking step

🤖 Generated with [Claude Code](https://claude.com/claude-code)