### PR TITLE
Start 3.x development: require PHP 8.4+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,11 @@ jobs:
           MYSQL_DATABASE: example
           MYSQL_USER: example
           MYSQL_PASSWORD: example
+          MYSQL_AUTHENTICATION_PLUGIN: ${{ matrix.auth_plugin }}
+          # MySQL 8.4 disables mysql_native_password by default, but the
+          # MariaDB client on the runner cannot use caching_sha2_password
+          # without TLS, so the plugin is re-enabled via server flag.
+          MYSQL_EXTRA_FLAGS: ${{ matrix.mysql_extra_flags }}
         ports:
           # Opens port 3306 on service container and host
           # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
@@ -45,30 +50,37 @@ jobs:
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.4
+            auth_plugin: mysql_native_password
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.5
+            auth_plugin: mysql_native_password
 
-          # MySQL 8.4 LTS
+          # MySQL 8.4 LTS (no auth_plugin: the default_authentication_plugin
+          # server option was removed in 8.4)
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.4.5
             php-version: 8.4
+            mysql_extra_flags: --mysql-native-password=ON
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.4.5
             php-version: 8.5
+            mysql_extra_flags: --mysql-native-password=ON
 
           # MariaDB 10.11 LTS
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9
             php-version: 8.4
+            auth_plugin: mysql_native_password
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9
             php-version: 8.5
+            auth_plugin: mysql_native_password
 
     steps:
 
@@ -99,9 +111,10 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Create user and databases for testing
-        env:
-          MYSQL_PWD: example
-        run: cat docker-entrypoint-initdb.d/${{ matrix.database }}-init.sql | mysql -h127.0.0.1 -uroot
+        # Run inside the service container over the local socket: on
+        # MySQL 8.4 the root user uses caching_sha2_password, which the
+        # runner's MariaDB client cannot authenticate with over plain TCP.
+        run: cat docker-entrypoint-initdb.d/${{ matrix.database }}-init.sql | docker exec -i -e MYSQL_PWD=example db mysql -uroot
 
       - name: Run test script
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
           MYSQL_DATABASE: example
           MYSQL_USER: example
           MYSQL_PASSWORD: example
-          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         ports:
           # Opens port 3306 on service container and host
           # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
@@ -49,6 +48,16 @@ jobs:
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
+            php-version: 8.5
+
+          # MySQL 8.4 LTS
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnamilegacy/mysql:8.4.5
+            php-version: 8.4
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnamilegacy/mysql:8.4.5
             php-version: 8.5
 
           # MariaDB 10.11 LTS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,18 +45,6 @@ jobs:
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
-            php-version: 8.1
-          - os: ubuntu-24.04
-            database: mysql
-            database_image: bitnamilegacy/mysql:8.0.40
-            php-version: 8.2
-          - os: ubuntu-24.04
-            database: mysql
-            database_image: bitnamilegacy/mysql:8.0.40
-            php-version: 8.3
-          - os: ubuntu-24.04
-            database: mysql
-            database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.4
           - os: ubuntu-24.04
             database: mysql
@@ -64,18 +52,6 @@ jobs:
             php-version: 8.5
 
           # MariaDB 10.11 LTS
-          - os: ubuntu-22.04
-            database: mariadb
-            database_image: bitnamilegacy/mariadb:10.11.9
-            php-version: 8.1
-          - os: ubuntu-22.04
-            database: mariadb
-            database_image: bitnamilegacy/mariadb:10.11.9
-            php-version: 8.2
-          - os: ubuntu-22.04
-            database: mariadb
-            database_image: bitnamilegacy/mariadb:10.11.9
-            php-version: 8.3
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,18 @@ This file provides guidance for AI assistants working with the mysqldump-php cod
 
 - **Package**: `druidfi/mysqldump-php`
 - **License**: GPL-3.0-or-later
-- **PHP**: ^8.1 with PDO extension
+- **PHP**: ^8.4 with PDO extension
 - **Databases**: MySQL 8.0+, MariaDB 10.11+
+
+## Branches & Versioning
+
+| Version | Branch | PHP       | Status |
+|---------|--------|-----------|--------|
+| 3.x     | `main` | 8.4+      | In development (`dev-main` aliased as `3.x-dev`) |
+| 2.x     | `2.x`  | 8.1+      | Maintenance; 2.0.x releases are tagged from here |
+| 1.x     | `1.x`  | 7.4 / 8.0 | Legacy |
+
+Bug fixes relevant to both lines land on `main` first and are backported to `2.x`.
 
 ## Codebase Structure
 
@@ -62,7 +72,7 @@ docs/
 
 # Root-level Docker test setup
 Dockerfile                     # PHP test container (PHP_SHORT_VERSION build arg)
-compose.yaml                   # Services: mysql, mariadb, php81..php85
+compose.yaml                   # Services: mysql, mariadb, php84, php85
 config/skip-ssl.cnf            # MySQL client config for test containers
 docker-entrypoint-initdb.d/    # DB init scripts (mysql-init.sql, mariadb-init.sql)
 .env.mysql                     # Shared DB credentials for compose services
@@ -87,8 +97,8 @@ vendor/bin/rector process --dry-run
 cd tests/scripts && ./test.sh 127.0.0.1
 
 # Docker-based testing
-docker compose up mysql php81    # or php82, php83, php84, php85
-docker compose up mariadb php81  # same, against MariaDB
+docker compose up mysql php84    # or php85
+docker compose up mariadb php84  # same, against MariaDB
 ```
 
 ## Key Coding Conventions
@@ -152,9 +162,11 @@ Druidfi\Mysqldump\
 
 ### CI Matrix
 Tests run on:
-- PHP: 8.1, 8.2, 8.3, 8.4, 8.5
+- PHP: 8.4, 8.5
 - Databases: MySQL 8.0, MariaDB 10.11
-- Total: 10 combinations
+- Total: 4 combinations
+
+The `2.x` branch keeps the wider PHP 8.1–8.5 matrix (10 combinations).
 
 ## Static Analysis
 
@@ -166,14 +178,14 @@ vendor/bin/phpstan
 - Ignores errors for optional extensions (ext-zstd, ext-lz4)
 - Analyzes `src/` and `tests/`
 - **Not a direct dependency**: `phpstan/phpstan` is not in `require-dev`; it is available transitively via `rector/rector`
-- **Advisory in CI**: the PHPStan step runs with `continue-on-error: true`, so failures do not block PRs
+- **Blocking in CI**: PHPStan failures fail the build
 
 ### Rector
 ```bash
 vendor/bin/rector process --dry-run
 ```
 - Configured in `rector.php`
-- Target: PHP 8.1
+- Target: PHP 8.4
 - Used for code modernization checks
 
 ## Architecture Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance for AI assistants working with the mysqldump-php cod
 - **Package**: `druidfi/mysqldump-php`
 - **License**: GPL-3.0-or-later
 - **PHP**: ^8.4 with PDO extension
-- **Databases**: MySQL 8.0+, MariaDB 10.11+
+- **Databases**: MySQL 8.0+ (including 8.4 LTS), MariaDB 10.11+
 
 ## Branches & Versioning
 
@@ -72,7 +72,7 @@ docs/
 
 # Root-level Docker test setup
 Dockerfile                     # PHP test container (PHP_SHORT_VERSION build arg)
-compose.yaml                   # Services: mysql, mariadb, php84, php85
+compose.yaml                   # Services: mysql, mysql84, mariadb, php84, php85
 config/skip-ssl.cnf            # MySQL client config for test containers
 docker-entrypoint-initdb.d/    # DB init scripts (mysql-init.sql, mariadb-init.sql)
 .env.mysql                     # Shared DB credentials for compose services
@@ -97,7 +97,7 @@ vendor/bin/rector process --dry-run
 cd tests/scripts && ./test.sh 127.0.0.1
 
 # Docker-based testing
-docker compose up mysql php84    # or php85
+docker compose up mysql php84    # or php85; mysql84 for MySQL 8.4 LTS
 docker compose up mariadb php84  # same, against MariaDB
 ```
 
@@ -163,8 +163,8 @@ Druidfi\Mysqldump\
 ### CI Matrix
 Tests run on:
 - PHP: 8.4, 8.5
-- Databases: MySQL 8.0, MariaDB 10.11
-- Total: 4 combinations
+- Databases: MySQL 8.0, MySQL 8.4 LTS, MariaDB 10.11
+- Total: 6 combinations
 
 The `2.x` branch keeps the wider PHP 8.1–8.5 matrix (10 combinations).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-ARG PHP_SHORT_VERSION=82
+ARG PHP_SHORT_VERSION=84
 
-FROM php:8.1 AS php-81
-FROM php:8.2 AS php-82
-FROM php:8.3 AS php-83
 FROM php:8.4 AS php-84
 FROM php:8.5.0beta2 AS php-85
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ composer install
 docker compose up --wait --build
 docker compose exec -w /app/tests/scripts php84 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php85 ./test.sh mysql
+docker compose exec -w /app/tests/scripts php84 ./test.sh mysql84
+docker compose exec -w /app/tests/scripts php85 ./test.sh mysql84
 docker compose exec -w /app/tests/scripts php84 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php85 ./test.sh mariadb
 ```

--- a/README.md
+++ b/README.md
@@ -26,8 +26,16 @@ Out of the box, `mysqldump-php` supports backing up table structures, the data i
 
 ## Requirements
 
-- PHP 8.1 or newer with PDO - [see supported versions](https://www.php.net/supported-versions.php)
+- PHP 8.4 or newer with PDO - [see supported versions](https://www.php.net/supported-versions.php)
 - MySQL 8.0 or newer (and compatible MariaDB)
+
+## Versions
+
+| Version | Branch | PHP       | Status |
+|---------|--------|-----------|--------|
+| 3.x     | `main` | 8.4+      | In development |
+| 2.x     | `2.x`  | 8.1+      | Maintenance |
+| 1.x     | `1.x`  | 7.4 / 8.0 | Legacy |
 
 ## Installing
 
@@ -246,14 +254,8 @@ Local setup for tests:
 ```console
 composer install
 docker compose up --wait --build
-docker compose exec -w /app/tests/scripts php81 ./test.sh mysql
-docker compose exec -w /app/tests/scripts php82 ./test.sh mysql
-docker compose exec -w /app/tests/scripts php83 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php84 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php85 ./test.sh mysql
-docker compose exec -w /app/tests/scripts php81 ./test.sh mariadb
-docker compose exec -w /app/tests/scripts php82 ./test.sh mariadb
-docker compose exec -w /app/tests/scripts php83 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php84 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php85 ./test.sh mariadb
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,9 @@ services:
   mysql84:
     container_name: mysqldump-php-mysql-84
     image: mysql:8.4
+    # mysql_native_password is disabled by default in 8.4; the test user
+    # still needs it (see docker-entrypoint-initdb.d/mysql-init.sql)
+    command: --mysql-native-password=ON
     env_file:
       - .env.mysql
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,45 +16,6 @@ services:
     volumes:
       - ./docker-entrypoint-initdb.d/mariadb-init.sql:/docker-entrypoint-initdb.d/00-init.sql
 
-  php81:
-    container_name: mysqldump-php-81
-    build:
-      context: .
-      args:
-        PHP_SHORT_VERSION: 81
-    volumes:
-      - .:/app
-      - ./config/skip-ssl.cnf:/etc/my.cnf.d/skip-ssl.cnf
-    depends_on:
-      - mysql
-      - mariadb
-
-  php82:
-    container_name: mysqldump-php-82
-    build:
-      context: .
-      args:
-        PHP_SHORT_VERSION: 82
-    volumes:
-      - .:/app
-      - ./config/skip-ssl.cnf:/etc/my.cnf.d/skip-ssl.cnf
-    depends_on:
-      - mysql
-      - mariadb
-
-  php83:
-    container_name: mysqldump-php-83
-    build:
-      context: .
-      args:
-        PHP_SHORT_VERSION: 83
-    volumes:
-      - .:/app
-      - ./config/skip-ssl.cnf:/etc/my.cnf.d/skip-ssl.cnf
-    depends_on:
-      - mysql
-      - mariadb
-
   php84:
     container_name: mysqldump-php-84
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,14 @@ services:
     volumes:
       - ./docker-entrypoint-initdb.d/mysql-init.sql:/docker-entrypoint-initdb.d/00-init.sql
 
+  mysql84:
+    container_name: mysqldump-php-mysql-84
+    image: mysql:8.4
+    env_file:
+      - .env.mysql
+    volumes:
+      - ./docker-entrypoint-initdb.d/mysql-init.sql:/docker-entrypoint-initdb.d/00-init.sql
+
   mariadb:
     container_name: mysqldump-php-mariadb-10
     image: mariadb:10.11

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,19 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.4",
         "composer-runtime-api": "^2",
         "ext-pdo": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^12",
         "rector/rector": "^2.3"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "3.x-dev"
+        }
     },
     "autoload": {
         "psr-4": {

--- a/docker-entrypoint-initdb.d/mysql-init.sql
+++ b/docker-entrypoint-initdb.d/mysql-init.sql
@@ -1,4 +1,9 @@
-CREATE USER IF NOT EXISTS 'example'@'%' IDENTIFIED WITH mysql_native_password BY 'example';
+-- The container entrypoint may have already created this user with the
+-- server default plugin (caching_sha2_password on MySQL 8.4), so force
+-- mysql_native_password with ALTER USER: the MariaDB client used in tests
+-- cannot authenticate with caching_sha2_password over plain TCP.
+CREATE USER IF NOT EXISTS 'example'@'%';
+ALTER USER 'example'@'%' IDENTIFIED WITH mysql_native_password BY 'example';
 GRANT ALL ON *.* TO 'example'@'%';
 
 CREATE DATABASE IF NOT EXISTS test001;

--- a/docker-entrypoint-initdb.d/mysql-init.sql
+++ b/docker-entrypoint-initdb.d/mysql-init.sql
@@ -1,4 +1,4 @@
-CREATE USER IF NOT EXISTS 'example'@'%' IDENTIFIED WITH mysql_native_password BY 'example';
+CREATE USER IF NOT EXISTS 'example'@'%' IDENTIFIED BY 'example';
 GRANT ALL ON *.* TO 'example'@'%';
 
 CREATE DATABASE IF NOT EXISTS test001;

--- a/docker-entrypoint-initdb.d/mysql-init.sql
+++ b/docker-entrypoint-initdb.d/mysql-init.sql
@@ -1,4 +1,4 @@
-CREATE USER IF NOT EXISTS 'example'@'%' IDENTIFIED BY 'example';
+CREATE USER IF NOT EXISTS 'example'@'%' IDENTIFIED WITH mysql_native_password BY 'example';
 GRANT ALL ON *.* TO 'example'@'%';
 
 CREATE DATABASE IF NOT EXISTS test001;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
   <testsuites>
     <testsuite name="default">
       <directory suffix="Test.php">tests</directory>

--- a/rector.php
+++ b/rector.php
@@ -10,7 +10,7 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    ->withPhpVersion(PhpVersion::PHP_81)
+    ->withPhpVersion(PhpVersion::PHP_84)
     // uncomment to reach your current PHP version
     // ->withPhpSets()
     ->withTypeCoverageLevel(0)

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -946,10 +946,10 @@ class Mysqldump
     {
         $colStmt = [];
         foreach ($this->tableColumnTypes[$tableName] as $colName => $colType) {
-            // TODO handle bug where PHP 8.1 returns double field wrong
             if ($colType['is_virtual']) {
                 $this->settings->setCompleteInsert();
-            } elseif ($colType['type'] == 'double' && PHP_VERSION_ID > 80100) {
+            } elseif ($colType['type'] == 'double') {
+                // PHP 8.1+ returns double fields with float precision issues; dump via CONCAT
                 $colStmt[] = sprintf("CONCAT(`%s`) AS `%s`", $colName, $colName);
             } elseif ($colType['type'] === 'bit' && $this->settings->isEnabled('hex-blob')) {
                 $colStmt[] = sprintf("LPAD(HEX(`%s`),2,'0') AS `%s`", $colName, $colName);


### PR DESCRIPTION
## Summary

Bootstraps 3.x development on `main`, requiring PHP 8.4+. The new [`2.x` branch](https://github.com/druidfi/mysqldump-php/tree/2.x) continues PHP 8.1+ maintenance for 2.0.x releases (it already has its CI push trigger fixed — unlike the `1.x` precedent, pushes to `2.x` run the full 10-job matrix).

## Changes

- **composer.json**: `php: ^8.1` → `^8.4`; `phpunit/phpunit: ^10.5` → `^12`; added `branch-alias` mapping `dev-main` → `3.x-dev` so Packagist versions the default branch correctly against the existing 2.0.x tags
- **phpunit.xml**: migrated to the PHPUnit 12.5 schema via `--migrate-configuration`
- **CI matrix**: PHP 8.4/8.5 × MySQL 8.0 / **MySQL 8.4 LTS** / MariaDB 10.11 = 6 jobs (MySQL 8.0 community support ends April 2026, so the current LTS is now covered)
- **MySQL 8.4 auth handling**: 8.4 disables `mysql_native_password` by default, but the runner's `mysql` binary is the MariaDB client, which cannot authenticate with `caching_sha2_password` over plain TCP. So: the plugin is re-enabled on 8.4 via `MYSQL_EXTRA_FLAGS=--mysql-native-password=ON`, the test user is forced onto it with `ALTER USER` (the container entrypoint pre-creates the user with the server default, making `CREATE USER IF NOT EXISTS` a no-op), and the root init step now runs inside the service container over the local socket
- **Docker**: removed `php81`–`php83` compose services and Dockerfile stages; default `PHP_SHORT_VERSION` is now 84; added `mysql84` compose service (with the same native-password flag) for local testing against MySQL 8.4
- **rector.php**: target PHP 8.4
- **src/Mysqldump.php**: removed the `PHP_VERSION_ID > 80100` guard on the `double`-column CONCAT workaround — with PHP 8.4 as the floor it was dead code (PHPStan flags it as `greater.alwaysTrue`)
- **README**: PHP 8.4+ requirement, new version/branch table (3.x = `main`, 2.x = maintenance, 1.x = legacy), Docker test examples updated
- **CLAUDE.md**: branch strategy section, PHP/CI/Rector references updated, PHPStan note corrected to "blocking in CI"

## Follow-ups (not in this PR)

- Actual PHP 8.4 code modernization (property hooks, Rector `withPhpSets()`)
- Any BC-breaking API changes planned for 3.0
- Consider adding MySQL 8.4 to the `2.x` branch matrix as well

## Test plan

- [x] `vendor/bin/phpunit` — 60 tests, 143 assertions, OK on PHPUnit 12.5.30
- [x] `vendor/bin/phpstan` — 0 errors (blocking step)
- [x] `vendor/bin/rector process --dry-run` — clean
- [x] `composer validate` — valid
- [x] CI matrix green: all 6 jobs, including MySQL 8.4 integration tests comparing against its native mysqldump

🤖 Generated with [Claude Code](https://claude.com/claude-code)