### PR TITLE
Add MySQL 8.4 LTS to 2.x CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,11 @@ jobs:
           MYSQL_DATABASE: example
           MYSQL_USER: example
           MYSQL_PASSWORD: example
-          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
+          MYSQL_AUTHENTICATION_PLUGIN: ${{ matrix.auth_plugin }}
+          # MySQL 8.4 disables mysql_native_password by default, but the
+          # MariaDB client on the runner cannot use caching_sha2_password
+          # without TLS, so the plugin is re-enabled via server flag.
+          MYSQL_EXTRA_FLAGS: ${{ matrix.mysql_extra_flags }}
         ports:
           # Opens port 3306 on service container and host
           # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
@@ -46,44 +50,82 @@ jobs:
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.1
+            auth_plugin: mysql_native_password
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.2
+            auth_plugin: mysql_native_password
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.3
+            auth_plugin: mysql_native_password
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.4
+            auth_plugin: mysql_native_password
           - os: ubuntu-24.04
             database: mysql
             database_image: bitnamilegacy/mysql:8.0.40
             php-version: 8.5
+            auth_plugin: mysql_native_password
+
+          # MySQL 8.4 LTS (no auth_plugin: the default_authentication_plugin
+          # server option was removed in 8.4)
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnamilegacy/mysql:8.4.5
+            php-version: 8.1
+            mysql_extra_flags: --mysql-native-password=ON
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnamilegacy/mysql:8.4.5
+            php-version: 8.2
+            mysql_extra_flags: --mysql-native-password=ON
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnamilegacy/mysql:8.4.5
+            php-version: 8.3
+            mysql_extra_flags: --mysql-native-password=ON
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnamilegacy/mysql:8.4.5
+            php-version: 8.4
+            mysql_extra_flags: --mysql-native-password=ON
+          - os: ubuntu-24.04
+            database: mysql
+            database_image: bitnamilegacy/mysql:8.4.5
+            php-version: 8.5
+            mysql_extra_flags: --mysql-native-password=ON
 
           # MariaDB 10.11 LTS
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9
             php-version: 8.1
+            auth_plugin: mysql_native_password
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9
             php-version: 8.2
+            auth_plugin: mysql_native_password
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9
             php-version: 8.3
+            auth_plugin: mysql_native_password
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9
             php-version: 8.4
+            auth_plugin: mysql_native_password
           - os: ubuntu-22.04
             database: mariadb
             database_image: bitnamilegacy/mariadb:10.11.9
             php-version: 8.5
+            auth_plugin: mysql_native_password
 
     steps:
 
@@ -114,9 +156,10 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Create user and databases for testing
-        env:
-          MYSQL_PWD: example
-        run: cat docker-entrypoint-initdb.d/${{ matrix.database }}-init.sql | mysql -h127.0.0.1 -uroot
+        # Run inside the service container over the local socket: on
+        # MySQL 8.4 the root user uses caching_sha2_password, which the
+        # runner's MariaDB client cannot authenticate with over plain TCP.
+        run: cat docker-entrypoint-initdb.d/${{ matrix.database }}-init.sql | docker exec -i -e MYSQL_PWD=example db mysql -uroot
 
       - name: Run test script
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ docs/
 
 # Root-level Docker test setup
 Dockerfile                     # PHP test container (PHP_SHORT_VERSION build arg)
-compose.yaml                   # Services: mysql, mariadb, php81..php85
+compose.yaml                   # Services: mysql, mysql84, mariadb, php81..php85
 config/skip-ssl.cnf            # MySQL client config for test containers
 docker-entrypoint-initdb.d/    # DB init scripts (mysql-init.sql, mariadb-init.sql)
 .env.mysql                     # Shared DB credentials for compose services
@@ -153,8 +153,8 @@ Druidfi\Mysqldump\
 ### CI Matrix
 Tests run on:
 - PHP: 8.1, 8.2, 8.3, 8.4, 8.5
-- Databases: MySQL 8.0, MariaDB 10.11
-- Total: 10 combinations
+- Databases: MySQL 8.0, MySQL 8.4 LTS, MariaDB 10.11
+- Total: 15 combinations
 
 ## Static Analysis
 
@@ -166,7 +166,7 @@ vendor/bin/phpstan
 - Ignores errors for optional extensions (ext-zstd, ext-lz4)
 - Analyzes `src/` and `tests/`
 - **Not a direct dependency**: `phpstan/phpstan` is not in `require-dev`; it is available transitively via `rector/rector`
-- **Advisory in CI**: the PHPStan step runs with `continue-on-error: true`, so failures do not block PRs
+- **Blocking in CI**: PHPStan failures fail the build
 
 ### Rector
 ```bash

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ docker compose exec -w /app/tests/scripts php82 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php83 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php84 ./test.sh mysql
 docker compose exec -w /app/tests/scripts php85 ./test.sh mysql
+docker compose exec -w /app/tests/scripts php81 ./test.sh mysql84
+docker compose exec -w /app/tests/scripts php82 ./test.sh mysql84
+docker compose exec -w /app/tests/scripts php83 ./test.sh mysql84
+docker compose exec -w /app/tests/scripts php84 ./test.sh mysql84
+docker compose exec -w /app/tests/scripts php85 ./test.sh mysql84
 docker compose exec -w /app/tests/scripts php81 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php82 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php83 ./test.sh mariadb

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,17 @@ services:
     volumes:
       - ./docker-entrypoint-initdb.d/mysql-init.sql:/docker-entrypoint-initdb.d/00-init.sql
 
+  mysql84:
+    container_name: mysqldump-php-mysql-84
+    image: mysql:8.4
+    # mysql_native_password is disabled by default in 8.4; the test user
+    # still needs it (see docker-entrypoint-initdb.d/mysql-init.sql)
+    command: --mysql-native-password=ON
+    env_file:
+      - .env.mysql
+    volumes:
+      - ./docker-entrypoint-initdb.d/mysql-init.sql:/docker-entrypoint-initdb.d/00-init.sql
+
   mariadb:
     container_name: mysqldump-php-mariadb-10
     image: mariadb:10.11

--- a/docker-entrypoint-initdb.d/mysql-init.sql
+++ b/docker-entrypoint-initdb.d/mysql-init.sql
@@ -1,4 +1,9 @@
-CREATE USER IF NOT EXISTS 'example'@'%' IDENTIFIED WITH mysql_native_password BY 'example';
+-- The container entrypoint may have already created this user with the
+-- server default plugin (caching_sha2_password on MySQL 8.4), so force
+-- mysql_native_password with ALTER USER: the MariaDB client used in tests
+-- cannot authenticate with caching_sha2_password over plain TCP.
+CREATE USER IF NOT EXISTS 'example'@'%';
+ALTER USER 'example'@'%' IDENTIFIED WITH mysql_native_password BY 'example';
 GRANT ALL ON *.* TO 'example'@'%';
 
 CREATE DATABASE IF NOT EXISTS test001;


### PR DESCRIPTION
## Summary

Backports MySQL 8.4 LTS support from `main` (#81) to the `2.x` maintenance branch. MySQL 8.0 community support ends April 2026 and 2.x will be maintained past that, so the current LTS is now covered here too.

## Changes

- **CI matrix**: 5 new MySQL 8.4.5 jobs (PHP 8.1–8.5) → 15 combinations total (was 10)
- **Auth handling** (same as #81): MySQL 8.4 disables `mysql_native_password` by default and the runner's `mysql` binary is the MariaDB client, which cannot authenticate with `caching_sha2_password` over plain TCP. So the plugin is re-enabled on 8.4 via `MYSQL_EXTRA_FLAGS=--mysql-native-password=ON`, the test user is forced onto it with `ALTER USER` (the container entrypoint pre-creates the user with the server default), and the root init step runs inside the service container over the local socket
- **compose.yaml**: new `mysql84` service (`mysql:8.4` with `--mysql-native-password=ON`) for local testing; README gains the corresponding `./test.sh mysql84` examples
- **CLAUDE.md**: CI matrix updated to 15 combinations; also corrected the stale "PHPStan is advisory" note — the `continue-on-error` was removed in #80, which predates this branch

## Test plan

- [x] All 15 CI jobs green, including the 5 new MySQL 8.4 jobs comparing output against its native mysqldump (the same integration tests already pass on main with PHP 8.4/8.5; this additionally covers PHP 8.1–8.3 against MySQL 8.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)