### PR TITLE
chore: update 3.x task list and skip CI for docs-only changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,17 @@ on:
     branches:
       # Push events on main branch
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,170 +1,188 @@
-# Improvement Tasks for mysqldump-php
+# Improvement Tasks for mysqldump-php (3.x / PHP 8.4+)
 
-This document contains a detailed list of actionable improvement tasks for the mysqldump-php project. Each task is marked with a checkbox that can be checked off when completed.
+This document contains a detailed list of actionable improvement tasks for the 3.x line (`main` branch, PHP 8.4+).
+Each task is marked with a checkbox that can be checked off when completed. Tasks are grounded in the current
+codebase; items that are done are kept checked for history.
 
 ## Architecture Improvements
 
-1. [ ] Refactor the large Mysqldump class into smaller, more focused classes:
+1. [ ] Refactor the large Mysqldump class (~1090 lines) into smaller, more focused classes:
    - [x] Create a separate DatabaseConnector class to handle connection logic
    - [x] Create a separate DumpWriter class to handle file output
    - [x] Create separate classes for different database object types (Tables, Views, Triggers, etc.)
+   - [ ] Extract table data dumping (`listValues()`, `prepareListValues()`, `endListValues()`,
+         `prepareColumnValues()`, `getColumnStmt()`, `getColumnNames()`) into a dedicated class
+   - [ ] Remove the vestigial `getDatabaseStructure*()` methods: five are empty no-ops and
+         `getDatabaseStructureTables()` only validates include-tables (rename to `validateIncludedTables()`)
+   - [ ] Deduplicate the six near-identical `iterate*()` generators into one shared helper
+         (query + column extraction + optional include filter)
 
-2. [ ] Implement a proper dependency injection system:
-   - [ ] Use constructor injection for dependencies
-   - [ ] Consider using a dependency injection container for complex dependencies
+2. [ ] Improve dependency wiring:
+   - [ ] Fix `Mysqldump::$adapterClass` being `static` — `addTypeAdapter()` leaks the adapter
+         across all instances in the same process; make it an instance property
+   - [ ] Pass ObjectDumper dependencies more explicitly instead of six positional closures
+         (e.g. a small context object or named-argument value object)
+   - [ ] Reconsider `PDO::ATTR_PERSISTENT => true` as a hardcoded default in DatabaseConnector
 
 3. [ ] Improve error handling:
-   - [ ] Create custom exception classes for different error types
-   - [ ] Add more specific error messages
-   - [ ] Implement proper exception hierarchies
+   - [ ] Create custom exception classes (e.g. `ConnectionException`, `ConfigurationException`,
+         `DumpException`) extending a common `MysqldumpException`; everything currently throws bare `Exception`
+   - [ ] Implement a proper exception hierarchy and document which methods throw what
 
 4. [ ] Implement interfaces for major components:
    - [x] Create a DumperInterface for different dumper implementations
-   - [ ] Create a ConnectionInterface for different database connections
+   - [ ] Create a ConnectionInterface so DatabaseConnector can be swapped/mocked
+
+## PHP 8.4 Modernization (new in 3.x)
+
+5. [ ] Adopt PHP 8.4 language features now that older PHP support is dropped:
+   - [ ] Use constructor property promotion in `DatabaseConnector` and `Mysqldump`
+         (both still declare classic properties and assign in the constructor)
+   - [ ] Add typed class constants (PHP 8.3+): e.g. `const string UTF8 = 'utf8'` in `DumpSettings`,
+         and the string constants in `ConfigOption`
+   - [ ] Type the hook properties as `?Closure` (`$transformTableRowCallable`,
+         `$transformColumnValueCallable`, `$infoCallable` are currently untyped)
+   - [ ] Add missing return types: `getTableStructure()`, `getViewStructureTable()`,
+         `getViewStructureView()`, `getTriggerStructure()`, `getProcedureStructure()`,
+         `getFunctionStructure()`, `getEventStructure()`, `listValues()`, `prepareListValues()`,
+         `endListValues()`, `setTransformColumnValueHook()` lack `: void`
+   - [ ] Evaluate replacing the custom `Attribute\Deprecated` with the native PHP 8.4
+         `#[\Deprecated]` attribute (native triggers automatic deprecation notices; keep the
+         custom one only if the extra `removeIn`/`alternative` metadata is worth it)
+   - [ ] Use `array_any()` / `array_find()` (PHP 8.4) to simplify `matches()`
+   - [ ] Evaluate property hooks / asymmetric visibility where they simplify getters
+         (e.g. `DatabaseConnector::$host` / `$dbName`)
+
+6. [ ] Introduce enums for closed value sets:
+   - [ ] Backed enum for compression methods — this would also fix the current drift:
+         `ConfigOption::COMPRESS` allows `['None', 'Gzip', 'Bzip2', 'Zstandard', 'LZ4']` while
+         `CompressManagerFactory` uses `Gzipstream`, `Zstd`, `Lz4`
+   - [ ] Enum for insert type (`INSERT` / `INSERT IGNORE` / `REPLACE`) replacing `getInsertType()` strings
+
+7. [ ] Tighten tooling now that the floor is PHP 8.4:
+   - [ ] Enable `->withPhpSets()` in `rector.php` (currently commented out) and raise
+         `withTypeCoverageLevel` / `withDeadCodeLevel` / `withCodeQualityLevel` from 0
+   - [ ] Raise PHPStan from level 4 towards 6+ and fix findings
 
 ## Code Quality Improvements
 
-5. [ ] Reduce code duplication:
-   - [ ] Refactor similar methods in Mysqldump.php (getDatabaseStructure*, export*)
-   - [ ] Create utility methods for common operations
-   - [ ] Use inheritance or traits for shared functionality
+8. [ ] Reduce code duplication:
+   - [ ] Refactor the near-identical `getProcedureStructure()` / `getFunctionStructure()` /
+         `getEventStructure()` / `getTriggerStructure()` "show create + write" pattern
+   - [ ] Extract the repeated comment-header writing (`skipComments()` + sprintf block) into a helper
 
-6. [ ] Improve method organization:
-   - [ ] Group related methods together
-   - [ ] Extract private helper methods for complex operations
-   - [ ] Reduce method sizes for better readability
+9. [ ] Improve method organization:
+   - [ ] Break up `listValues()` (~95 lines) into smaller private methods
+   - [ ] Group related methods together in `Mysqldump.php`
 
-7. [x] Enhance type safety:
-   - [x] Add return type declarations to all methods
-   - [x] Add parameter type declarations to all methods
-   - [x] Use strict typing throughout the codebase
+10. [x] Enhance type safety (baseline):
+    - [x] Add return type declarations to public API methods
+    - [x] Add parameter type declarations to all methods
+    - [x] Use strict typing throughout the codebase
+    - Note: remaining gaps are itemized under task 5
 
-8. [ ] Implement better validation:
-   - [ ] Validate input parameters more thoroughly
-   - [ ] Add assertions for critical assumptions
-   - [ ] Implement proper boundary checks
-
-9. [x] Utilize native PHP Attributes (PHP 8.0+):
-   - [x] Use attributes for configuration metadata (e.g., marking default values, constraints)
-   - [x] Apply attributes for validation rules on settings and parameters
-   - [x] Consider attributes for dependency injection metadata
-   - [x] Use attributes to mark deprecated methods/classes
-   - [x] Document attribute usage patterns in code examples
+11. [ ] Implement better validation:
+    - [ ] `matches()` reads `$pattern[0]` — an empty string in include/exclude/no-data arrays causes
+          an error; validate patterns up front
+    - [ ] Fix `DumpSettings::get()` casting every setting to `string` — return proper types or add
+          typed getters
+    - [ ] Validate `net_buffer_length` and other numeric settings via `Constraint` attributes
 
 ## Documentation Improvements
 
-10. [ ] Improve code documentation:
-    - [ ] Add PHPDoc blocks to all classes and methods
-    - [ ] Document parameters, return types, and exceptions
-    - [ ] Add examples for complex methods
+12. [ ] Improve code documentation:
+    - [ ] Document `@throws` consistently once custom exceptions exist (task 3)
+    - [ ] Remove stale PHPDoc (e.g. `getDatabaseStructure*` docblocks say "Fills $this->tables array",
+          which no longer exists)
 
-11. [ ] Create comprehensive user documentation:
-    - [ ] Write a getting started guide
-    - [ ] Document all configuration options
-    - [ ] Provide examples for common use cases
-    - [ ] Create a FAQ section
-
-12. [ ] Add architecture documentation:
-    - [ ] Create class diagrams
-    - [ ] Document the overall system design
-    - [ ] Explain key design decisions
+13. [ ] Improve user documentation (README already covers install, hooks, settings, privileges):
+    - [ ] Document 2.x → 3.x upgrade / breaking changes
+    - [ ] Replace references to the ifsnop wiki with own examples
+    - [ ] Document compression options incl. optional ext-zstd / ext-lz4 requirements
+    - [ ] Document dumping to stream wrappers (gs://, s3:// via league/flysystem etc.)
+          instead of adding cloud SDK dependencies to the library
 
 ## Testing Improvements
 
-13. [x] Enhance unit testing:
+14. [x] Enhance unit testing:
     - [x] Increase test coverage for core functionality
     - [x] Add tests for edge cases
     - [x] Implement proper mocking for dependencies
 
-14. [ ] Implement integration testing:
-    - [ ] Test with different database versions
-    - [ ] Test with different PHP versions
-    - [ ] Test with different configuration options
+15. [ ] Extend integration testing (CI already runs PHP 8.4/8.5 × MySQL 8.0/8.4/MariaDB 10.11 and
+        compares output against native mysqldump):
+    - [x] Test with different database versions
+    - [x] Test with different PHP versions
+    - [ ] Broaden dump-settings coverage in `tests/scripts/test.sh` (e.g. compression methods,
+          `complete-insert`, `no-data` patterns, `skip-definer`)
+    - [ ] Add MariaDB 11.x LTS to the matrix when supported by the test images
 
-15. [ ] Add performance testing:
-    - [ ] Benchmark dump operations
-    - [ ] Test with large databases
-    - [ ] Identify and optimize bottlenecks
-
-16. [ ] Improve test organization:
-    - [ ] Group tests by functionality
-    - [ ] Use data providers for similar test cases
-    - [ ] Implement test fixtures for common test data
+16. [ ] Add performance testing:
+    - [ ] Benchmark dump operations against a large fixture database
+    - [ ] Compare speed/memory against native mysqldump and document results
 
 ## Performance Improvements
 
 17. [ ] Optimize memory usage:
     - [x] Review and optimize large data structures
-    - [ ] Implement streaming for large dumps
     - [x] Use generators for large result sets
-
-18. [ ] Improve database query performance:
-    - [ ] Review and optimize SQL queries
-    - [ ] Implement query batching where appropriate
-    - [ ] Add indexes for frequently queried data
-
-19. [ ] Enhance concurrency:
-    - [ ] Implement parallel processing for independent operations
-    - [ ] Use non-blocking I/O where appropriate
-    - [ ] Optimize transaction handling
+    - [ ] Make the `iterate*()` generators truly streaming — they currently buffer all names into
+          an array before yielding
+    - [ ] Review `$tableColumnTypes` growth on databases with many tables/columns
 
 ## Security Improvements
 
-20. [ ] Enhance security measures:
-    - [ ] Implement proper input validation
-    - [ ] Use prepared statements consistently
-    - [ ] Sanitize all user input
+18. [ ] Harden identifier and input handling (classic prepared statements don't apply to
+        identifiers or to a dump tool's SHOW/SELECT flow):
+    - [ ] Escape/validate table names consistently when interpolated into SQL
+          (e.g. `` `$tableName` `` in `listValues()`; a name containing a backtick would break the query)
+    - [ ] Document that `where`, `tableWheres` and `tableLimits` are raw SQL by design and must not
+          contain untrusted input
 
-21. [ ] Improve credential handling:
-    - [ ] Support secure credential storage
-    - [ ] Implement credential rotation
-    - [ ] Add support for environment variables
-
-22. [ ] Add security documentation:
-    - [ ] Document security best practices
-    - [ ] Provide guidance on secure configuration
-    - [ ] Create a security policy
+19. [ ] Improve security posture of the project:
+    - [ ] Add a SECURITY.md with a vulnerability reporting policy
+    - [ ] Document secure credential practices (env vars, secret managers) in the README
+          — actual credential storage/rotation is the caller's responsibility, not the library's
 
 ## Feature Enhancements
 
-23. [x] Add new compression options:
+20. [x] Add new compression options:
     - [x] Support for Zstandard compression
     - [x] Support for LZ4 compression
     - [x] Configurable compression levels
 
-24. [ ] Enhance data transformation capabilities:
-    - [ ] Add more powerful data anonymization features
-    - [ ] Support for complex data transformations
-    - [ ] Add filtering capabilities
+21. [ ] Enhance data transformation capabilities:
+    - [ ] Provide ready-made anonymization helpers/recipes on top of the existing hooks
+    - [ ] Support returning `null` from hooks to skip a row entirely (row filtering)
 
-25. [ ] Improve cloud storage support:
-    - [ ] Add support for AWS S3
-    - [ ] Add support for Azure Blob Storage
-    - [ ] Implement resumable uploads
-
-26. [ ] Implement progress reporting:
-    - [ ] Add detailed progress information
-    - [ ] Support for progress callbacks
-    - [ ] Implement ETA calculations
+22. [ ] Improve progress reporting (an `infoHook` with per-table row counts already exists):
+    - [ ] Report total table count / overall progress, not just per-table row counts
+    - [ ] Document the info hook payload shape in the README
 
 ## Maintenance Improvements
 
-27. [ ] Update dependencies:
-    - [ ] Review and update all dependencies
-    - [ ] Implement dependency version constraints
-    - [ ] Document dependency requirements
+23. [ ] Project housekeeping:
+    - [x] Automate dependency updates (Renovate is configured)
+    - [ ] Decide on `squizlabs/php_codesniffer` in require-dev: it has no ruleset and is not run
+          in CI — either add a PSR-12 ruleset + CI step or remove the dependency
+    - [ ] Create issue templates and contribution guidelines
+    - [ ] Tag a 3.0.0 release once the modernization tasks above land; add release notes template
 
-28. [ ] Improve build and release process:
-    - [ ] Implement semantic versioning
-    - [ ] Automate release process
-    - [ ] Create release notes template
+24. [x] Implement static analysis and modernization tooling:
+    - [x] PHPStan (level 4) blocking in CI
+    - [x] Rector dry-run blocking in CI
+    - Note: raising strictness levels is tracked in task 7
 
-29. [ ] Enhance project management:
-    - [ ] Create issue templates
-    - [ ] Implement contribution guidelines
-    - [ ] Add a code of conduct
+## Dropped from the previous version of this list
 
-30. [ ] Implement coding standards:
-    - [ ] Adopt PSR-12 coding standard
-    - [ ] Add automated code style checking
-    - [ ] Implement static analysis tools
+Removed as out of scope or not applicable to a dump library, so they stop showing up as "open work":
+
+- *Dependency injection container* — overkill for a small library; plain constructor injection (task 2) suffices.
+- *Add indexes for frequently queried data* — the library only reads schemas/data; indexing is the user's database concern.
+- *Parallel processing / non-blocking I/O* — conflicts with `single-transaction` consistent-snapshot semantics.
+- *Credential rotation / secure credential storage* — caller's responsibility; replaced by documentation task 19.
+- *Native AWS S3 / Azure Blob support* — would add heavy SDK dependencies; stream wrappers already work
+  (replaced by documentation task 13).
+- *Use prepared statements consistently* — identifiers cannot be bound; replaced by identifier escaping task 18.
+- *Class diagrams / architecture docs* — the codebase is ~3200 lines across small classes; CLAUDE.md and
+  the README cover the architecture adequately.


### PR DESCRIPTION
## What

Two housekeeping changes:

1. **Rewrite `docs/tasks.md` against the current 3.x codebase.** Marks completed items (CI matrix, static analysis, Renovate), drops tasks out of scope for a dump library (DI container, parallel dumps, cloud SDKs, credential rotation — listed at the bottom with rationale), and adds concrete PHP 8.4-era tasks found in the code:
   - static `Mysqldump::$adapterClass` leaks the adapter across instances
   - `ConfigOption::COMPRESS` allowed values have drifted from `CompressManagerFactory` method names
   - dead no-op `getDatabaseStructure*()` methods and copy-pasted `iterate*()` generators
   - missing `: void` return types and untyped hook properties (`?Closure`)
   - rector PHP sets commented out and quality levels at 0; PHPStan headroom above level 4

2. **Add `paths-ignore` to the test workflow** so `**.md`, `docs/**`, `LICENSE` and `.gitignore` changes don't spend 6 matrix jobs on a run that can't fail.

## Why

The task list predated the 3.x split and no longer reflected reality — several items were already done, others don't apply now that PHP <8.4 support is dropped. And doc-only pushes currently trigger the full 6-job test matrix.

## Testing

- `docs/tasks.md` is documentation only
- Tests **do** run on this PR since it modifies `tests.yml` itself (not an ignored path) — the skip behaviour will show on the next docs-only PR after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)