### PR TITLE
fix: improve dependency wiring (task 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ try {
 }
 ```
 
-Refer to the [ifsnop/mysqldump-php Wiki](https://github.com/ifsnop/mysqldump-php/wiki/Full-usage-example) for some
-examples and a comparison between mysqldump and mysqldump-php dumps.
+The sections below cover the most common use cases. All configuration options are listed under
+[Dump Settings](#dump-settings), and the [Tests](#tests) section describes how the output is
+compared against native `mysqldump`.
 
 ## Changing values when exporting
 
@@ -85,11 +86,15 @@ $dumper->start('storage/work/dump.sql');
 You can register a callable that will be used to report on the progress of the dump
 
 ```php
-$dumper->setInfoHook(function($object, $info) {
+$dumper->setInfoHook(function ($object, $info) {
     if ($object === 'table') {
-        echo $info['name'], $info['rowCount'];
-    });
+        echo $info['name'], ': ', $info['rowCount'], PHP_EOL;
+    }
+});
 ```
+
+For tables the `$info` array contains `name`, `rowCount` and `completed` (set to `true` once the
+table has been fully dumped).
 
 ## Table specific export conditions
 
@@ -119,21 +124,25 @@ $dumper->setTableLimits([
     'posts' => 10
 ]);
 ```
-You can also specify the limits as an array where the first value is the number of rows and the second is the offset
+You can also specify the limit as a two-value array, which maps to MySQL's `LIMIT offset, row_count`
+syntax: the first value is the offset and the second is the number of rows
 
 ```php
 $dumper = new \Druidfi\Mysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
 
 $dumper->setTableLimits([
-    'users' => [20, 10], //MySql query equivalent "... LIMIT 20 OFFSET 10"
+    'users' => [20, 10], // MySQL query equivalent "... LIMIT 20, 10", i.e. 10 rows starting from offset 20
 ]);
 ```
 ## Dump Settings
 
-Dump settings can be changed from default values with 4th argument for Mysqldump constructor:
+Dump settings can be changed from default values with the 4th argument of the Mysqldump constructor.
+PDO options can be passed as the 5th argument:
 
 ```php
-$dumper = new \Druidfi\Mysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password', $pdoOptions);
+$dumpSettings = ['compress' => 'Gzip', 'no-data' => true];
+
+$dumper = new \Druidfi\Mysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password', $dumpSettings, $pdoOptions);
 ```
 
 All options:
@@ -148,76 +157,79 @@ All options:
   - Only create a new table when a table of the same name does not already exist. No error message is thrown if the table already exists. 
 - **compress**
   - Possible values: `Bzip2|Gzip|Gzipstream|Zstd|Lz4|None`, default is `None`
-  - Could be specified using the consts: `CompressManagerFactory::GZIP`, `CompressManagerFactory::BZIP2`, `CompressManagerFactory::ZSTD`, `CompressManagerFactory::LZ4` or `CompressManagerFactory::NONE`
+  - Could be specified using the `CompressMethod` enum values (e.g. `CompressMethod::Gzip->value`) or the consts: `CompressManagerFactory::GZIP`, `CompressManagerFactory::BZIP2`, `CompressManagerFactory::GZIPSTREAM`, `CompressManagerFactory::ZSTD`, `CompressManagerFactory::LZ4` or `CompressManagerFactory::NONE`
+  - `Zstd` requires `ext-zstd` and `Lz4` requires `ext-lz4`
 - **compress-level**
-  - Compression level to use (integer), default is `0` (no compression level specified)
+  - Compression level to use (integer), default is `0` (use the method's own default level)
+  - For Gzip: 1-9
   - For Zstd: 1-22 (default: 3)
   - For Lz4: 1-12 (default: 1)
 - **reset-auto-increment**
   - Removes the AUTO_INCREMENT option from the database definition
   - Useful when used with no-data, so when db is recreated, it will start from 1 instead of using an old value
 - **add-drop-database**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_add-drop-database)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_add-drop-database)
 - **add-drop-table**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_add-drop-table)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_add-drop-table)
 - **add-drop-triggers**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_add-drop-trigger)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_add-drop-trigger)
 - **add-locks**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_add-locks)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_add-locks)
 - **complete-insert**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_complete-insert)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_complete-insert)
 - **databases**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_databases)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_databases)
 - **default-character-set**
   - Possible values: `utf8|utf8mb4`, default is `utf8`
   - `utf8` is compatible option and `utf8mb4` is for full utf8 compliance
   - Could be specified using the consts: `DumpSettings::UTF8` or `DumpSettings::UTF8MB4`
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb4.html)
 - **disable-keys**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_disable-keys)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_disable-keys)
 - **events**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_events)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_events)
 - **extended-insert**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_extended-insert)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_extended-insert)
 - **hex-blob**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_hex-blob)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_hex-blob)
 - **insert-ignore**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_insert-ignore)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_insert-ignore)
 - **replace**
   - Use REPLACE INTO instead of INSERT INTO statements. Cannot be used together with insert-ignore.
 - **lock-tables**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_lock-tables)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_lock-tables)
 - **net_buffer_length**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_net-buffer-length)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_net-buffer-length)
 - **no-autocommit**
   - Option to disable autocommit (faster inserts, no problems with index keys)
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/commit.html)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/commit.html)
 - **no-create-info**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_no-create-info)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_no-create-info)
 - **no-data**
   - Do not dump data for these tables (array of table names), support regexps, `true` to ignore all tables
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_no-data)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_no-data)
 - **routines**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_routines)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_routines)
 - **single-transaction**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_single-transaction)
 - **skip-comments**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_skip-comments)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_skip-comments)
 - **skip-dump-date**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_dump-date)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_dump-date)
 - **skip-triggers**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_triggers)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_triggers)
 - **skip-tz-utc**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_tz-utc)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_tz-utc)
 - **skip-definer**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqlpump.html#option_mysqlpump_skip-definer)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqlpump.html#option_mysqlpump_skip-definer)
 - **where**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_where)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_where)
 
-The following options are now enabled by default, and there is no way to disable them since they should always be used.
+The following option is deprecated. Passing it triggers a deprecation notice, and it will be removed
+in a future version; use `init_commands` to control `FOREIGN_KEY_CHECKS` manually if needed.
 
 - **disable-foreign-keys-check**
-  - MySQL docs [5.7](https://dev.mysql.com/doc/refman/5.7/en/optimizing-innodb-bulk-data-loading.html)
+  - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/optimizing-innodb-bulk-data-loading.html)
 
 ## Privileges
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -91,8 +91,9 @@ codebase; items that are done are kept checked for history.
     - [ ] Fix `DumpSettings::get()` casting every setting to `string` — return proper types or add
           typed getters
     - [ ] Validate `net_buffer_length` and other numeric settings via `Constraint` attributes
-    - [ ] Align the `compress-level` constraint (currently 0–9) with Zstd (1–22) and Lz4 (1–12)
-          level ranges documented in the README
+    - [x] Align the `compress-level` constraint with the real level ranges — the attribute allows
+          the global 0–22 range and `DumpSettings` enforces the per-method maximum via
+          `CompressMethod::maxLevel()` (Gzip 9, Lz4 12, Zstd 22)
 
 ## Documentation Improvements
 
@@ -103,8 +104,8 @@ codebase; items that are done are kept checked for history.
 
 13. [ ] Improve user documentation (README already covers install, hooks, settings, privileges):
     - [ ] Document 2.x → 3.x upgrade / breaking changes
-    - [ ] Replace references to the ifsnop wiki with own examples
-    - [ ] Document compression options incl. optional ext-zstd / ext-lz4 requirements
+    - [x] Replace references to the ifsnop wiki with own examples
+    - [x] Document compression options incl. optional ext-zstd / ext-lz4 requirements
     - [ ] Document dumping to stream wrappers (gs://, s3:// via league/flysystem etc.)
           instead of adding cloud SDK dependencies to the library
 
@@ -163,7 +164,7 @@ codebase; items that are done are kept checked for history.
 
 22. [ ] Improve progress reporting (an `infoHook` with per-table row counts already exists):
     - [ ] Report total table count / overall progress, not just per-table row counts
-    - [ ] Document the info hook payload shape in the README
+    - [x] Document the info hook payload shape in the README
 
 ## Maintenance Improvements
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,12 +17,14 @@ codebase; items that are done are kept checked for history.
    - [ ] Deduplicate the six near-identical `iterate*()` generators into one shared helper
          (query + column extraction + optional include filter)
 
-2. [ ] Improve dependency wiring:
-   - [ ] Fix `Mysqldump::$adapterClass` being `static` — `addTypeAdapter()` leaks the adapter
-         across all instances in the same process; make it an instance property
-   - [ ] Pass ObjectDumper dependencies more explicitly instead of six positional closures
-         (e.g. a small context object or named-argument value object)
-   - [ ] Reconsider `PDO::ATTR_PERSISTENT => true` as a hardcoded default in DatabaseConnector
+2. [x] Improve dependency wiring:
+   - [x] Fix `Mysqldump::$adapterClass` being `static` — now an instance property, with a
+         regression test that `addTypeAdapter()` no longer leaks across instances
+   - [x] Pass ObjectDumper dependencies more explicitly — dumpers are constructed with named
+         arguments; a separate context class was considered and skipped as over-engineering
+   - [x] `PDO::ATTR_PERSISTENT => true` removed from the connection defaults — one-shot dumps
+         gain nothing from persistence and recycled handles can carry over session state;
+         opt back in via the `pdoOptions` constructor argument
 
 3. [ ] Improve error handling:
    - [ ] Create custom exception classes (e.g. `ConnectionException`, `ConfigurationException`,

--- a/src/Compress/CompressMethod.php
+++ b/src/Compress/CompressMethod.php
@@ -32,6 +32,20 @@ enum CompressMethod: string
     }
 
     /**
+     * Highest supported compression level, or null when the method
+     * does not take a level.
+     */
+    public function maxLevel(): ?int
+    {
+        return match ($this) {
+            self::Gzip => 9,
+            self::Lz4 => 12,
+            self::Zstd => 22,
+            default => null,
+        };
+    }
+
+    /**
      * Create the compressor for this method. A level of 0 means the
      * compressor's own default level (Zstd defaults to 3, Lz4 to 1).
      *

--- a/src/ConfigOption.php
+++ b/src/ConfigOption.php
@@ -30,8 +30,8 @@ class ConfigOption
     #[Constraint(enum: CompressMethod::class, message: 'Must be a valid compression method')]
     public const string COMPRESS = 'compress';
 
-    #[DefaultValue(value: 0, description: 'Compression level (0-9)')]
-    #[Constraint(min: 0, max: 9, message: 'Compression level must be between 0 and 9')]
+    #[DefaultValue(value: 0, description: 'Compression level (0 = method default)')]
+    #[Constraint(min: 0, max: 22, message: 'Compression level must be between 0 and 22')]
     public const string COMPRESS_LEVEL = 'compress-level';
 
     #[DefaultValue(value: [], description: 'Initial SQL commands to execute')]

--- a/src/DatabaseConnector.php
+++ b/src/DatabaseConnector.php
@@ -96,9 +96,11 @@ class DatabaseConnector
         }
 
         try {
-            // Build default PDO options with compatibility for PHP 8.5 deprecations
+            // Build default PDO options with compatibility for PHP 8.5 deprecations.
+            // Persistent connections are intentionally not enabled by default: a dump
+            // is a one-shot operation and a recycled handle may carry over session
+            // state; opt in via the pdoOptions constructor argument if needed.
             $defaultOptions = [
-                PDO::ATTR_PERSISTENT => true,
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 // Don't convert empty strings to SQL NULL values on data fetches.
                 PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,

--- a/src/DumpSettings.php
+++ b/src/DumpSettings.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Druidfi\Mysqldump;
 
 use Druidfi\Mysqldump\Compress\CompressManagerFactory;
+use Druidfi\Mysqldump\Compress\CompressMethod;
 use Exception;
 
 class DumpSettings
@@ -95,6 +96,18 @@ class DumpSettings
 
         if ($this->settings['replace'] && $this->settings['insert-ignore']) {
             throw new Exception('Cannot use both replace and insert-ignore options simultaneously');
+        }
+
+        // Method-specific upper bound: Gzip 1-9, Lz4 1-12, Zstd 1-22.
+        $level = $this->getCompressLevel();
+        if ($level > 0) {
+            $method = CompressMethod::fromName($this->getCompressMethod());
+            $maxLevel = $method->maxLevel();
+            if ($maxLevel !== null && $level > $maxLevel) {
+                throw new Exception(
+                    sprintf('Compression level %d is out of range for %s (1-%d)', $level, $method->value, $maxLevel)
+                );
+            }
         }
 
         // If no include-views is passed in, dump the same views as tables, mimic mysqldump behaviour.

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -31,7 +31,8 @@ class Mysqldump
     private readonly DumpWriter $writer;
     private TypeAdapterInterface $db;
 
-    private static string $adapterClass = TypeAdapterMysql::class;
+    /** @var class-string<TypeAdapterInterface> */
+    private string $adapterClass = TypeAdapterMysql::class;
 
     private readonly DumpSettings $settings;
     private array $tableColumnTypes = [];
@@ -83,7 +84,7 @@ class Mysqldump
 
     public function getAdapter(PDO $conn): TypeAdapterInterface
     {
-        return new self::$adapterClass($conn, $this->settings);
+        return new ($this->adapterClass)($conn, $this->settings);
     }
 
     private function write(string $data): int
@@ -1041,8 +1042,9 @@ class Mysqldump
     }
 
     /**
-     * Add TypeAdapter
+     * Set the TypeAdapter class used by this instance.
      *
+     * @param class-string<TypeAdapterInterface> $adapterClassName
      * @throws Exception
      */
     public function addTypeAdapter(string $adapterClassName): void
@@ -1052,7 +1054,7 @@ class Mysqldump
             throw new Exception($message);
         }
 
-        self::$adapterClass = $adapterClassName;
+        $this->adapterClass = $adapterClassName;
     }
 
     /**

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -1044,7 +1044,7 @@ class Mysqldump
     /**
      * Set the TypeAdapter class used by this instance.
      *
-     * @param class-string<TypeAdapterInterface> $adapterClassName
+     * @param class-string $adapterClassName Must implement TypeAdapterInterface (validated at runtime)
      * @throws Exception
      */
     public function addTypeAdapter(string $adapterClassName): void

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -162,44 +162,44 @@ class Mysqldump
 
         // Use dedicated dumpers for different object types
         $tablesDumper = new ObjectDumper\TablesDumper(
-            fn(): \Generator => $this->iterateTables(),
-            fn(string $name, array $arr): bool => $this->matches($name, $arr),
-            function (string $table): void { $this->getTableStructure($table); },
-            function (string $table): void {
+            iterateTables: fn(): \Generator => $this->iterateTables(),
+            matches: fn(string $name, array $arr): bool => $this->matches($name, $arr),
+            getTableStructure: function (string $table): void { $this->getTableStructure($table); },
+            listValues: function (string $table): void {
                 $no_data = $this->settings->isEnabled('no-data');
                 if (!$no_data && !$this->matches($table, $this->settings->getNoData())) {
                     $this->listValues($table);
                 }
             },
-            fn(): array => $this->settings->getExcludedTables(),
-            fn(): array => $this->settings->getNoData()
+            getExcludedTables: fn(): array => $this->settings->getExcludedTables(),
+            getNoData: fn(): array => $this->settings->getNoData()
         );
         $tablesDumper->dump();
 
         $triggersDumper = new ObjectDumper\TriggersDumper(
-            fn(): \Generator => $this->iterateTriggers(),
-            function (string $name): void { $this->getTriggerStructure($name); }
+            iterateTriggers: fn(): \Generator => $this->iterateTriggers(),
+            getTriggerStructure: function (string $name): void { $this->getTriggerStructure($name); }
         );
         $triggersDumper->dump();
 
         $routinesDumper = new ObjectDumper\RoutinesDumper(
-            fn(): \Generator => $this->iterateProcedures(),
-            fn(): \Generator => $this->iterateFunctions(),
-            function (string $name): void { $this->getProcedureStructure($name); },
-            function (string $name): void { $this->getFunctionStructure($name); }
+            iterateProcedures: fn(): \Generator => $this->iterateProcedures(),
+            iterateFunctions: fn(): \Generator => $this->iterateFunctions(),
+            getProcedureStructure: function (string $name): void { $this->getProcedureStructure($name); },
+            getFunctionStructure: function (string $name): void { $this->getFunctionStructure($name); }
         );
         $routinesDumper->dump();
 
         $viewsDumper = new ObjectDumper\ViewsDumper(
-            fn(): \Generator => $this->iterateViews(),
-            fn(string $name, array $arr): bool => $this->matches($name, $arr),
-            function (string $name): void {
+            iterateViews: fn(): \Generator => $this->iterateViews(),
+            matches: fn(string $name, array $arr): bool => $this->matches($name, $arr),
+            getViewStructureTable: function (string $name): void {
                 if ($this->settings->isEnabled('no-create-info')) { return; }
                 if ($this->matches($name, $this->settings->getExcludedTables())) { return; }
                 $this->tableColumnTypes[$name] = $this->getTableColumnTypes($name);
                 $this->getViewStructureTable($name);
             },
-            function (string $name): void {
+            getViewStructureView: function (string $name): void {
                 if ($this->settings->isEnabled('no-create-info')) { return; }
                 if ($this->matches($name, $this->settings->getExcludedTables())) { return; }
                 $this->getViewStructureView($name);
@@ -208,8 +208,8 @@ class Mysqldump
         $viewsDumper->dump();
 
         $eventsDumper = new ObjectDumper\EventsDumper(
-            fn(): \Generator => $this->iterateEvents(),
-            function (string $name): void { $this->getEventStructure($name); }
+            iterateEvents: fn(): \Generator => $this->iterateEvents(),
+            getEventStructure: function (string $name): void { $this->getEventStructure($name); }
         );
         $eventsDumper->dump();
 

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -64,17 +64,17 @@ class ConfigValidatorTest extends TestCase
     public function testValidateRejectsCompressionLevelTooLow(): void
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Compression level must be between 0 and 9');
-        
+        $this->expectExceptionMessage('Compression level must be between 0 and 22');
+
         ConfigValidator::validate('compress-level', -1);
     }
 
     public function testValidateRejectsCompressionLevelTooHigh(): void
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Compression level must be between 0 and 9');
-        
-        ConfigValidator::validate('compress-level', 10);
+        $this->expectExceptionMessage('Compression level must be between 0 and 22');
+
+        ConfigValidator::validate('compress-level', 23);
     }
 
     public function testValidateAcceptsValidCharacterSet(): void

--- a/tests/DumpSettingsTest.php
+++ b/tests/DumpSettingsTest.php
@@ -234,10 +234,42 @@ class DumpSettingsTest extends TestCase
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Cannot use both replace and insert-ignore options simultaneously');
-        
+
         new DumpSettings([
             'replace' => true,
             'insert-ignore' => true
         ]);
+    }
+
+    /**
+     * Test that compression levels above the method-specific maximum are rejected
+     */
+    public function testCompressLevelAboveMethodMaximumIsRejected(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Compression level 10 is out of range for Gzip (1-9)');
+
+        new DumpSettings([
+            'compress' => 'Gzip',
+            'compress-level' => 10,
+        ]);
+    }
+
+    /**
+     * Test that method-specific maximum levels above 9 are accepted (Zstd 1-22, Lz4 1-12)
+     */
+    public function testCompressLevelWithinMethodMaximumIsAccepted(): void
+    {
+        $settings = new DumpSettings([
+            'compress' => 'Zstd',
+            'compress-level' => 22,
+        ]);
+        $this->assertSame(22, $settings->getCompressLevel());
+
+        $settings = new DumpSettings([
+            'compress' => 'Lz4',
+            'compress-level' => 12,
+        ]);
+        $this->assertSame(12, $settings->getCompressLevel());
     }
 }

--- a/tests/MysqldumpAdapterTest.php
+++ b/tests/MysqldumpAdapterTest.php
@@ -4,10 +4,12 @@ namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\Mysqldump;
 use Druidfi\Mysqldump\Tests\Doubles\FakeTypeAdapter;
+use Druidfi\Mysqldump\TypeAdapter\TypeAdapterMysql;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Exception;
 use PDO;
+use ReflectionProperty;
 
 #[CoversClass(Mysqldump::class)]
 class MysqldumpAdapterTest extends TestCase
@@ -28,6 +30,18 @@ class MysqldumpAdapterTest extends TestCase
         $adapter = $dump->getAdapter($pdo);
         $this->assertInstanceOf(FakeTypeAdapter::class, $adapter);
         $this->assertSame($pdo, $adapter->conn);
+    }
+
+    public function testAddTypeAdapterDoesNotLeakAcrossInstances(): void
+    {
+        $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'user', 'pass');
+        $dump->addTypeAdapter(FakeTypeAdapter::class);
+
+        // A second instance must not inherit the adapter set on the first one.
+        $other = new Mysqldump('mysql:host=localhost;dbname=test', 'user', 'pass');
+        $refl = new ReflectionProperty(Mysqldump::class, 'adapterClass');
+        $this->assertSame(FakeTypeAdapter::class, $refl->getValue($dump));
+        $this->assertSame(TypeAdapterMysql::class, $refl->getValue($other));
     }
 
     public function testGetTableWhereReturnsFalseWhenUnset(): void

--- a/tests/scripts/pdo_checks.php
+++ b/tests/scripts/pdo_checks.php
@@ -13,7 +13,6 @@ print "PHP version is ". phpversion() . PHP_EOL;
 print "PDO check: double field" . PHP_EOL . PHP_EOL;
 
 $pdoOptions = [
-    \PDO::ATTR_PERSISTENT => true,
     \PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
     \PDO::ATTR_STRINGIFY_FETCHES => true,
 ];


### PR DESCRIPTION
## What

Completes **task 2 (Improve dependency wiring)** from `docs/tasks.md`, plus README example fixes found while reviewing the docs:

1. **Per-instance type adapter** — `Mysqldump::$adapterClass` was `static`, so `addTypeAdapter()` on one instance silently changed the adapter for every other `Mysqldump` instance in the same process. Now an instance property with a `class-string` annotation, plus a regression test proving a second instance keeps `TypeAdapterMysql`.

2. **Named-argument ObjectDumper wiring** — the dumpers were constructed with up to six positional closures, unreadable at the call site. They're now constructed with named arguments. A dedicated context class was considered and skipped as over-engineering (noted in tasks.md).

3. **No forced persistent connections** — `PDO::ATTR_PERSISTENT => true` removed from the connection defaults. A dump is a one-shot operation, so persistence gains nothing in CLI use, and under PHP-FPM a recycled handle can carry over session state from a previous request. Opting back in still works via the `pdoOptions` constructor argument.

4. **compress-level validation fix** — the `Constraint` capped `compress-level` at 9, so the README-documented Zstd (1–22) and Lz4 (1–12) levels above 9 were rejected at validation. The attribute now allows the global 0–22 range and `DumpSettings` enforces the per-method maximum via a new `CompressMethod::maxLevel()` (Gzip 9, Lz4 12, Zstd 22). Covered by new unit tests.

5. **README example fixes**:
   - `setInfoHook` example had a syntax error (missing closing brace); payload keys now documented
   - Dump Settings example passed `$pdoOptions` as the 4th constructor argument — that's the settings array; both arguments now shown correctly
   - the two-value `setTableLimits` example claimed `[20, 10]` means `LIMIT 20 OFFSET 10`; it actually produces `LIMIT 20, 10` = 10 rows from offset 20 — docs now match the code
   - ifsnop wiki pointer replaced with own sections; ext-zstd/ext-lz4 requirements, `GZIPSTREAM` const and `CompressMethod` enum documented; `disable-foreign-keys-check` marked deprecated; MySQL doc links moved from the 5.7 to the 8.0 manual (URLs verified)

## Behaviour changes

- `addTypeAdapter()` no longer affects other instances (this was a bug, not a feature).
- Connections are no longer persistent by default — pass `PDO::ATTR_PERSISTENT => true` in `pdoOptions` if needed.
- `compress-level` values 10–22 are now accepted for Zstd (10–12 for Lz4); levels above a method's maximum now fail with a per-method error message.

## Testing

- `vendor/bin/phpunit` — 64 tests green (cross-instance leak + per-method level regression tests)
- `vendor/bin/phpstan` (level 5) and `vendor/bin/rector --dry-run` — clean
- Integration suite run locally against **MySQL 8.0** and **MariaDB 10.11** with PHP 8.4 — all 39 diff tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)