### PR TITLE
docs: add 'Upgrading from 2.x to 3.x' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,33 @@ Out of the box, `mysqldump-php` supports backing up table structures, the data i
 | 2.x     | `2.x`  | 8.1+      | Maintenance | [![Run tests](https://github.com/druidfi/mysqldump-php/actions/workflows/tests.yml/badge.svg?branch=2.x)](https://github.com/druidfi/mysqldump-php/actions/workflows/tests.yml?query=branch%3A2.x) |
 | 1.x     | `1.x`  | 7.4 / 8.0 | Legacy | |
 
+## Upgrading from 2.x to 3.x
+
+The dump output and the day-to-day API — constructor, `start()`, the transform/info hooks,
+`setTableWheres()`/`setTableLimits()` and the dump settings with their defaults — are unchanged
+from 2.x. The following changes may require action:
+
+- **PHP 8.4 or newer is required** (2.x supports PHP 8.1+).
+- **Connections are no longer persistent by default.** 2.x always set
+  `PDO::ATTR_PERSISTENT => true`. If you relied on persistent connections, pass
+  `PDO::ATTR_PERSISTENT => true` in the `$pdoOptions` constructor argument.
+- **`Mysqldump::addTypeAdapter()` no longer affects other instances.** In 2.x the adapter class
+  was stored statically and leaked into every `Mysqldump` instance in the same process. Call
+  `addTypeAdapter()` on each instance that needs a custom adapter.
+- **`CompressManagerFactory::$methods` was removed.** Use the `CompressMethod` enum, or the
+  unchanged class constants such as `CompressManagerFactory::GZIP`.
+- **The `Druidfi\Mysqldump\Attribute\Deprecated` attribute class was removed.** Deprecations now
+  use the native PHP 8.4 `#[\Deprecated]` attribute.
+- **`ConfigValidator::checkDeprecated()` return value changed.** The `reason` and `alternative`
+  keys were replaced by a single `message` key (`deprecated` and `since` are unchanged).
+- **`compress-level` is validated per method.** Levels up to the method maximum are accepted
+  (Gzip 1-9, Lz4 1-12, Zstd 1-22) where 2.x rejected everything above 9, and a level above the
+  method maximum now throws with a method-specific message.
+
+Also fixed in 3.x with no action needed: 2.x settings validation rejected the `Zstd`, `Lz4` and
+`Gzipstream` compression methods due to a mismatch between the allowed values and the factory;
+they now validate correctly.
+
 ## Installing
 
 Install using [Composer](https://getcomposer.org/):

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -103,7 +103,7 @@ codebase; items that are done are kept checked for history.
           which no longer exists)
 
 13. [ ] Improve user documentation (README already covers install, hooks, settings, privileges):
-    - [ ] Document 2.x → 3.x upgrade / breaking changes
+    - [x] Document 2.x → 3.x upgrade / breaking changes (README "Upgrading from 2.x to 3.x")
     - [x] Replace references to the ifsnop wiki with own examples
     - [x] Document compression options incl. optional ext-zstd / ext-lz4 requirements
     - [ ] Document dumping to stream wrappers (gs://, s3:// via league/flysystem etc.)


### PR DESCRIPTION
## What

Adds an **Upgrading from 2.x to 3.x** section to the README (placed right after the Versions table), documenting the BC breaks. Checks off the corresponding task 13 item.

## How the list was produced

Diffed the public API surface (`public function`/`const`/statics of all classes in `src/`) and the `DumpSettings` defaults between `origin/2.x` and `main`, rather than working from memory. Notably: the defaults array, `TypeAdapterInterface`, `CompressInterface`, `DatabaseConnector` and all user-facing `Mysqldump` methods are identical — so dump output and everyday usage are unaffected.

The documented breaks:

1. PHP ^8.4 floor (was ^8.1)
2. `PDO::ATTR_PERSISTENT` no longer a default
3. `addTypeAdapter()` is per-instance
4. `CompressManagerFactory::$methods` removed
5. `Attribute\Deprecated` removed in favour of native `#[\Deprecated]`
6. `ConfigValidator::checkDeprecated()` return shape (`reason`/`alternative` → `message`)
7. `compress-level` per-method validation (Gzip 9, Lz4 12, Zstd 22 — 2.x capped everything at 9)

Plus a note that Zstd/Lz4/Gzipstream being rejected by 2.x validation is fixed with no action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)