### PR TITLE
refactor: dedupe iterate generators, drop getDatabaseStructure no-ops

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -12,10 +12,10 @@ codebase; items that are done are kept checked for history.
    - [x] Create separate classes for different database object types (Tables, Views, Triggers, etc.)
    - [ ] Extract table data dumping (`listValues()`, `prepareListValues()`, `endListValues()`,
          `prepareColumnValues()`, `getColumnStmt()`, `getColumnNames()`) into a dedicated class
-   - [ ] Remove the vestigial `getDatabaseStructure*()` methods: five are empty no-ops and
-         `getDatabaseStructureTables()` only validates include-tables (rename to `validateIncludedTables()`)
-   - [ ] Deduplicate the six near-identical `iterate*()` generators into one shared helper
-         (query + column extraction + optional include filter)
+   - [x] Remove the vestigial `getDatabaseStructure*()` methods: five were empty no-ops and
+         `getDatabaseStructureTables()` only validated include-tables (now `validateIncludedTables()`)
+   - [x] Deduplicate the six near-identical `iterate*()` generators into one shared
+         `iterateObjectNames()` helper (query + column extraction + optional include filter)
 
 2. [x] Improve dependency wiring:
    - [x] Fix `Mysqldump::$adapterClass` being `static` — now an instance property, with a
@@ -99,8 +99,8 @@ codebase; items that are done are kept checked for history.
 
 12. [ ] Improve code documentation:
     - [ ] Document `@throws` consistently once custom exceptions exist (task 3)
-    - [ ] Remove stale PHPDoc (e.g. `getDatabaseStructure*` docblocks say "Fills $this->tables array",
-          which no longer exists)
+    - [x] Remove stale PHPDoc — the `getDatabaseStructure*` docblocks claiming to fill a
+          non-existent `$this->tables` array went away with the methods themselves (task 1)
 
 13. [ ] Improve user documentation (README already covers install, hooks, settings, privileges):
     - [x] Document 2.x → 3.x upgrade / breaking changes (README "Upgrading from 2.x to 3.x")
@@ -133,8 +133,9 @@ codebase; items that are done are kept checked for history.
 17. [ ] Optimize memory usage:
     - [x] Review and optimize large data structures
     - [x] Use generators for large result sets
-    - [ ] Make the `iterate*()` generators truly streaming — they currently buffer all names into
-          an array before yielding
+    - [x] `iterate*()` generator buffering reviewed and kept as deliberate: only object *names*
+          are buffered (tiny), and the cursor must be closed before consumers run their own
+          queries per object — documented in `iterateObjectNames()`
     - [ ] Review `$tableColumnTypes` growth on databases with many tables/columns
 
 ## Security Improvements

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -148,13 +148,7 @@ class Mysqldump
             }
         }
 
-        // Get table, view, trigger, procedures, functions and events structures from database.
-        $this->getDatabaseStructureTables();
-        $this->getDatabaseStructureViews();
-        $this->getDatabaseStructureTriggers();
-        $this->getDatabaseStructureProcedures();
-        $this->getDatabaseStructureFunctions();
-        $this->getDatabaseStructureEvents();
+        $this->validateIncludedTables();
 
         if ($this->settings->isEnabled('databases')) {
             $this->write($this->db->databases($this->connector->getDbName()));
@@ -273,71 +267,25 @@ class Mysqldump
     }
 
     /**
-     * Reads table names from database. Fills $this->tables array so they will be dumped later.
+     * Validate that all include-tables entries actually exist in the database.
+     * This check will be removed once include-tables supports regexps.
      */
-    private function getDatabaseStructureTables(): void
+    private function validateIncludedTables(): void
     {
-        // Validate that all include-tables entries actually exist in the database.
         $includedTables = $this->settings->getIncludedTables();
-        if (!empty($includedTables)) {
-            $missingTables = $includedTables;
-            $stmtTables = $this->conn->query($this->db->showTables($this->connector->getDbName()));
-            foreach ($stmtTables as $row) {
-                $name = current($row);
-                $elem = array_search($name, $missingTables, true);
-                if ($elem !== false) {
-                    unset($missingTables[$elem]);
-                }
-            }
-            $stmtTables->closeCursor();
-            // If there still are some tables in $missingTables, they weren't found in the database.
-            // Give proper error and exit. This check will be removed once include-tables supports regexps.
-            if (!empty($missingTables)) {
-                $name = implode(',', $missingTables);
-                throw new Exception(sprintf("Table '%s' not found in database", $name));
-            }
+
+        if (empty($includedTables)) {
+            return;
         }
-        // $this->tables is intentionally left empty to avoid retaining the full list in memory.
-    }
 
-    /**
-     * Reads view names from database. Fills $this->tables array so they will be dumped later.
-     */
-    private function getDatabaseStructureViews(): void
-    {
-        // No need to store view names; validation for include-views happens in iterateViews()
-    }
+        $existingTables = iterator_to_array($this->iterateObjectNames(
+            $this->db->showTables($this->connector->getDbName())
+        ));
+        $missingTables = array_diff($includedTables, $existingTables);
 
-    /**
-     * Reads trigger names from database. Fills $this->tables array so they will be dumped later.
-     */
-    private function getDatabaseStructureTriggers(): void
-    {
-        // No need to store trigger names; iteration happens in iterateTriggers()
-    }
-
-    /**
-     * Reads procedure names from database. Fills $this->tables array so they will be dumped later.
-     */
-    private function getDatabaseStructureProcedures(): void
-    {
-        // No need to store procedure names; iteration happens in iterateProcedures()
-    }
-
-    /**
-     * Reads functions names from database. Fills $this->tables array so they will be dumped later.
-     */
-    private function getDatabaseStructureFunctions(): void
-    {
-        // No need to store function names; iteration happens in iterateFunctions()
-    }
-
-    /**
-     * Reads event names from database. Fills $this->tables array so they will be dumped later.
-     */
-    private function getDatabaseStructureEvents(): void
-    {
-        // No need to store event names; iteration happens in iterateEvents()
+        if (!empty($missingTables)) {
+            throw new Exception(sprintf("Table '%s' not found in database", implode(',', $missingTables)));
+        }
     }
 
     /**
@@ -354,110 +302,79 @@ class Mysqldump
     }
 
     /**
-     * Stream table names from the database without storing them in memory.
-     * Applies include-tables if provided, otherwise yields all tables.
+     * Yield object names of one type from the database.
+     *
+     * Names are buffered and the cursor closed before yielding, so the connection
+     * is free for the queries the consumer runs while dumping each object.
+     *
+     * @param string $query SHOW statement listing the objects
+     * @param string|null $column Result column holding the name; null takes the first column
+     * @param array $included When non-empty, only these names are yielded
      */
-    private function iterateTables(): \Generator
+    private function iterateObjectNames(string $query, ?string $column = null, array $included = []): \Generator
     {
-        $includedTables = $this->settings->getIncludedTables();
-        $restrict = !empty($includedTables);
-        $stmt = $this->conn->query($this->db->showTables($this->connector->getDbName()));
+        $stmt = $this->conn->query($query);
         $names = [];
+
         foreach ($stmt as $row) {
-            $name = current($row);
-            if (!$restrict || in_array($name, $includedTables, true)) {
+            $name = $column === null ? current($row) : $row[$column];
+            if (empty($included) || in_array($name, $included, true)) {
                 $names[] = $name;
             }
         }
+
         $stmt->closeCursor();
-        foreach ($names as $name) {
-            yield $name;
-        }
+
+        yield from $names;
+    }
+
+    private function iterateTables(): \Generator
+    {
+        yield from $this->iterateObjectNames(
+            $this->db->showTables($this->connector->getDbName()),
+            included: $this->settings->getIncludedTables()
+        );
     }
 
     private function iterateViews(): \Generator
     {
-        $included = $this->settings->getIncludedViews();
-        $restrict = !empty($included);
-        $stmt = $this->conn->query($this->db->showViews($this->connector->getDbName()));
-        $names = [];
-        foreach ($stmt as $row) {
-            $name = current($row);
-            if (!$restrict || in_array($name, $included, true)) {
-                $names[] = $name;
-            }
-        }
-        $stmt->closeCursor();
-        foreach ($names as $name) {
-            yield $name;
-        }
+        yield from $this->iterateObjectNames(
+            $this->db->showViews($this->connector->getDbName()),
+            included: $this->settings->getIncludedViews()
+        );
     }
 
     private function iterateTriggers(): \Generator
     {
-        if ($this->settings->skipTriggers()) {
-            yield from [];
-            return;
-        }
-        $stmt = $this->conn->query($this->db->showTriggers($this->connector->getDbName()));
-        $names = [];
-        foreach ($stmt as $row) {
-            $names[] = $row['Trigger'];
-        }
-        $stmt->closeCursor();
-        foreach ($names as $name) {
-            yield $name;
+        if (!$this->settings->skipTriggers()) {
+            yield from $this->iterateObjectNames($this->db->showTriggers($this->connector->getDbName()), 'Trigger');
         }
     }
 
     private function iterateProcedures(): \Generator
     {
-        if (!$this->settings->isEnabled('routines')) {
-            yield from [];
-            return;
-        }
-        $stmt = $this->conn->query($this->db->showProcedures($this->connector->getDbName()));
-        $names = [];
-        foreach ($stmt as $row) {
-            $names[] = $row['procedure_name'];
-        }
-        $stmt->closeCursor();
-        foreach ($names as $name) {
-            yield $name;
+        if ($this->settings->isEnabled('routines')) {
+            yield from $this->iterateObjectNames(
+                $this->db->showProcedures($this->connector->getDbName()),
+                'procedure_name'
+            );
         }
     }
 
     private function iterateFunctions(): \Generator
     {
-        if (!$this->settings->isEnabled('routines')) {
-            yield from [];
-            return;
-        }
-        $stmt = $this->conn->query($this->db->showFunctions($this->connector->getDbName()));
-        $names = [];
-        foreach ($stmt as $row) {
-            $names[] = $row['function_name'];
-        }
-        $stmt->closeCursor();
-        foreach ($names as $name) {
-            yield $name;
+        if ($this->settings->isEnabled('routines')) {
+            yield from $this->iterateObjectNames(
+                $this->db->showFunctions($this->connector->getDbName()),
+                'function_name'
+            );
         }
     }
 
     private function iterateEvents(): \Generator
     {
-        if (!$this->settings->isEnabled('events')) {
-            yield from [];
-            return;
-        }
-        $stmt = $this->conn->query($this->db->showEvents($this->connector->getDbName()));
-        $names = [];
-        foreach ($stmt as $row) {
-            $names[] = $row['event_name'];
-        }
-        $stmt->closeCursor();
-        foreach ($names as $name) {
-            yield $name;
+        if ($this->settings->isEnabled('events')) {
+            yield from $this->iterateObjectNames($this->db->showEvents($this->connector->getDbName()), 'event_name');
         }
     }
 


### PR DESCRIPTION
## What

Completes the remaining cleanup items of task 1 in `docs/tasks.md`:

- Removes the five vestigial `getDatabaseStructure*()` no-op methods and renames `getDatabaseStructureTables()` to `validateIncludedTables()`, which is all it actually did. Its manual search-and-unset loop is now an `array_diff()` against the existing table names (same exception message on missing tables), and the stale "Fills $this->tables array" docblocks are gone with it.
- Deduplicates the six near-identical `iterate*()` generators into one shared `iterateObjectNames()` helper (SHOW query + name-column extraction + optional include filter). The per-type methods remain as thin wrappers.

Net: −83 lines in `src/Mysqldump.php`.

## Why

Task 1 (refactor the large Mysqldump class) in the improvement roadmap. The no-ops and copy-pasted generators were leftovers from the 2.x structure-collection phase.

One deliberate non-change: the generators still buffer names before yielding. Only object *names* are buffered (negligible memory), and the cursor has to be closed before consumers run their own per-object queries on the same connection. This is now documented in the helper and the corresponding task 17 item is marked resolved-by-design.

## Testing

- `vendor/bin/phpunit` — 64 tests, 150 assertions, all pass
- `vendor/bin/phpstan` — clean (level 4)
- `vendor/bin/rector process --dry-run` — clean
- Integration suite (`tests/scripts/test.sh`) against MySQL 8.0 via `docker compose up mysql php84` — all 39 diff tests pass, output byte-identical to native mysqldump

🤖 Generated with [Claude Code](https://claude.com/claude-code)