### PR TITLE
chore(phpstan): raise analysis level from 5 to 6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
         run: vendor/bin/rector process --dry-run --no-progress-bar --ansi
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan --error-format=github --no-progress --ansi
+        run: vendor/bin/phpstan --error-format=github --no-progress --ansi --memory-limit=256M
 
       - name: Run PHPunit tests
         run: vendor/bin/phpunit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ composer install
 # Run PHPUnit tests
 vendor/bin/phpunit
 
-# Run static analysis (level 4)
+# Run static analysis (level 6)
 vendor/bin/phpstan
 
 # Run code modernization check (dry-run)
@@ -172,7 +172,7 @@ The `2.x` branch keeps the wider PHP 8.1–8.5 matrix (10 combinations).
 
 ## Static Analysis
 
-### PHPStan (Level 4)
+### PHPStan (Level 6)
 ```bash
 vendor/bin/phpstan
 ```

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - src/
         - tests/

--- a/src/Attribute/Constraint.php
+++ b/src/Attribute/Constraint.php
@@ -13,6 +13,7 @@ use Attribute;
 class Constraint
 {
     /**
+     * @param array<string|int>|null $allowedValues
      * @param class-string<\BackedEnum>|null $enum Backed enum whose values are the allowed values
      */
     public function __construct(

--- a/src/Attribute/ValidatesValue.php
+++ b/src/Attribute/ValidatesValue.php
@@ -12,6 +12,9 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class ValidatesValue
 {
+    /**
+     * @param array<string|int>|null $allowedValues
+     */
     public function __construct(
         public readonly ?string $type = null,
         public readonly bool $notNull = false,

--- a/src/Compress/CompressBzip2.php
+++ b/src/Compress/CompressBzip2.php
@@ -6,6 +6,7 @@ use Exception;
 
 class CompressBzip2 implements CompressInterface
 {
+    /** @var resource|false */
     private $fileHandler;
 
     /**

--- a/src/Compress/CompressGzip.php
+++ b/src/Compress/CompressGzip.php
@@ -6,6 +6,7 @@ use Exception;
 
 class CompressGzip implements CompressInterface
 {
+    /** @var resource|false */
     private $fileHandler;
     private readonly int $level;
 

--- a/src/Compress/CompressGzipstream.php
+++ b/src/Compress/CompressGzipstream.php
@@ -6,7 +6,9 @@ use Exception;
 
 class CompressGzipstream implements CompressInterface
 {
+    /** @var resource|false */
     private $fileHandler;
+    /** @var \DeflateContext|false */
     private $compressContext;
 
     /**

--- a/src/Compress/CompressLz4.php
+++ b/src/Compress/CompressLz4.php
@@ -6,6 +6,7 @@ use Exception;
 
 class CompressLz4 implements CompressInterface
 {
+    /** @var resource|false */
     private $fileHandler;
     private readonly int $compressionLevel;
 

--- a/src/Compress/CompressNone.php
+++ b/src/Compress/CompressNone.php
@@ -6,6 +6,7 @@ use Exception;
 
 class CompressNone implements CompressInterface
 {
+    /** @var resource|false */
     private $fileHandler;
 
     /**

--- a/src/Compress/CompressZstd.php
+++ b/src/Compress/CompressZstd.php
@@ -6,6 +6,7 @@ use Exception;
 
 class CompressZstd implements CompressInterface
 {
+    /** @var resource|false */
     private $fileHandler;
     private readonly int $compressionLevel;
 

--- a/src/ConfigValidator.php
+++ b/src/ConfigValidator.php
@@ -16,6 +16,9 @@ use ReflectionClassConstant;
  */
 class ConfigValidator
 {
+    /**
+     * @var array<string, array{default: mixed, description: string|null, constraint: Constraint|null, deprecated: Deprecated|null}>|null
+     */
     private static ?array $metadataCache = null;
 
     /**
@@ -43,6 +46,8 @@ class ConfigValidator
 
     /**
      * Extract attribute metadata from a constant.
+     *
+     * @return array{default: mixed, description: string|null, constraint: Constraint|null, deprecated: Deprecated|null}
      */
     private static function extractConstantMetadata(ReflectionClassConstant $constant): array
     {
@@ -181,7 +186,8 @@ class ConfigValidator
 
     /**
      * Validate all settings in a configuration array.
-     * 
+     *
+     * @param array<string, mixed> $settings
      * @throws Exception if any validation fails
      */
     public static function validateAll(array $settings): void

--- a/src/DatabaseConnector.php
+++ b/src/DatabaseConnector.php
@@ -27,7 +27,7 @@ class DatabaseConnector
      * @param string $dsn PDO DSN connection string
      * @param string|null $user SQL account username
      * @param string|null $pass SQL account password
-     * @param array $pdoOptions PDO configured attributes
+     * @param array<int, mixed> $pdoOptions PDO configured attributes
      * @throws Exception
      */
     public function __construct(

--- a/src/DumpSettings.php
+++ b/src/DumpSettings.php
@@ -13,6 +13,7 @@ class DumpSettings
     public const string UTF8    = 'utf8';
     public const string UTF8MB4 = 'utf8mb4';
 
+    /** @var array<string, mixed> */
     private static array $defaults = [
         'include-tables' => [],
         'exclude-tables' => [],
@@ -51,9 +52,11 @@ class DumpSettings
         /* deprecated */
         'disable-foreign-keys-check' => true
     ];
+    /** @var array<string, mixed> */
     private array $settings;
 
     /**
+     * @param array<string, mixed> $settings
      * @throws Exception
      */
     public function __construct(array $settings)
@@ -131,31 +134,49 @@ class DumpSettings
         return $this->settings['default-character-set'];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public static function getDefaults(): array
     {
         return self::$defaults;
     }
 
+    /**
+     * @return string[]
+     */
     public function getExcludedTables(): array
     {
         return $this->settings['exclude-tables'] ?? [];
     }
 
+    /**
+     * @return string[]
+     */
     public function getIncludedTables(): array
     {
         return $this->settings['include-tables'] ?? [];
     }
 
+    /**
+     * @param string[] $tables
+     */
     public function setIncludedTables(array $tables): void
     {
         $this->settings['include-tables'] = $tables;
     }
 
+    /**
+     * @return string[]
+     */
     public function getIncludedViews(): array
     {
         return $this->settings['include-views'] ?? [];
     }
 
+    /**
+     * @return string[]
+     */
     public function getInitCommands(): array
     {
         return $this->settings['init_commands'] ?? [];
@@ -166,6 +187,9 @@ class DumpSettings
         return $this->settings['net_buffer_length'];
     }
 
+    /**
+     * @return string[]
+     */
     public function getNoData(): array
     {
         $noData = $this->settings['no-data'] ?? [];

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -35,6 +35,7 @@ class Mysqldump
     private string $adapterClass = TypeAdapterMysql::class;
 
     private readonly DumpSettings $settings;
+    /** @var array<string, array<string, array<string, mixed>>> */
     private array $tableColumnTypes = [];
     private ?Closure $transformTableRowCallable = null;
     private ?Closure $transformColumnValueCallable = null;
@@ -43,8 +44,11 @@ class Mysqldump
     /**
      * Keyed on table name, with the value as the conditions.
      * e.g. - 'users' => 'date_registered > NOW() - INTERVAL 6 MONTH'
+     *
+     * @var array<string, string>
      */
     private array $tableWheres = [];
+    /** @var array<string, mixed> */
     private array $tableLimits = [];
 
     /**
@@ -53,8 +57,8 @@ class Mysqldump
      * @param string $dsn PDO DSN connection string
      * @param string|null $user SQL account username
      * @param string|null $pass SQL account password
-     * @param array $settings SQL database settings
-     * @param array $pdoOptions PDO configured attributes
+     * @param array<string, mixed> $settings SQL database settings
+     * @param array<int, mixed> $pdoOptions PDO configured attributes
      * @throws Exception
      */
     public function __construct(
@@ -290,6 +294,8 @@ class Mysqldump
 
     /**
      * Compare if $table name matches with a definition inside $arr.
+     *
+     * @param string[] $arr
      */
     private function matches(string $table, array $arr): bool
     {
@@ -309,7 +315,7 @@ class Mysqldump
      *
      * @param string $query SHOW statement listing the objects
      * @param string|null $column Result column holding the name; null takes the first column
-     * @param array $included When non-empty, only these names are yielded
+     * @param string[] $included When non-empty, only these names are yielded
      */
     private function iterateObjectNames(string $query, ?string $column = null, array $included = []): \Generator
     {
@@ -421,7 +427,7 @@ class Mysqldump
      * Store column types to create data dumps and for Stand-In tables.
      *
      * @param string $tableName Name of table to export
-     * @return array type column types detailed
+     * @return array<string, array<string, mixed>> type column types detailed
      */
     private function getTableColumnTypes(string $tableName): array
     {
@@ -634,7 +640,8 @@ class Mysqldump
      * Prepare values for output.
      *
      * @param string $tableName Name of table which contains rows
-     * @param array $row Associative array of column names and values to be quoted
+     * @param array<string, mixed> $row Associative array of column names and values to be quoted
+     * @return array<int, mixed> quoted values ready for the VALUES list
      */
     private function prepareColumnValues(string $tableName, array $row): array
     {
@@ -852,7 +859,7 @@ class Mysqldump
      *
      * @param string $tableName Name of table to get columns
      *
-     * @return array SQL sentence with columns for select
+     * @return string[] SQL sentence with columns for select
      */
     protected function getColumnStmt(string $tableName): array
     {
@@ -880,7 +887,7 @@ class Mysqldump
      *
      * @param string $tableName Name of table to get columns
      *
-     * @return array columns for sql sentence for insert
+     * @return string[] columns for sql sentence for insert
      */
     private function getColumnNames(string $tableName): array
     {
@@ -899,6 +906,8 @@ class Mysqldump
 
     /**
      * Get table column types.
+     *
+     * @return array<string, array<string, array<string, mixed>>>
      */
     protected function tableColumnTypes(): array
     {
@@ -908,6 +917,8 @@ class Mysqldump
     /**
      * Keyed by table name, with the value as the conditions:
      * e.g. 'users' => 'date_registered > NOW() - INTERVAL 6 MONTH AND deleted=0'
+     *
+     * @param array<string, string> $tableWheres
      */
     public function setTableWheres(array $tableWheres): void
     {
@@ -927,6 +938,8 @@ class Mysqldump
 
     /**
      * Keyed by table name, with the value as the numeric limit: e.g. 'users' => 3000
+     *
+     * @param array<string, mixed> $tableLimits
      */
     public function setTableLimits(array $tableLimits): void
     {

--- a/src/TypeAdapter/TypeAdapterInterface.php
+++ b/src/TypeAdapter/TypeAdapterInterface.php
@@ -8,12 +8,25 @@ interface TypeAdapterInterface
     public function addDropTrigger(string $triggerName): string;
     public function backupParameters(): string;
     public function commitTransaction(): string;
+
+    /** @param array<string, mixed> $row Row from the corresponding SHOW CREATE statement */
     public function createEvent(array $row): string;
+
+    /** @param array<string, mixed> $row Row from the corresponding SHOW CREATE statement */
     public function createFunction(array $row): string;
+
+    /** @param array<string, mixed> $row Row from the corresponding SHOW CREATE statement */
     public function createProcedure(array $row): string;
+
+    /** @param array<string, mixed> $row Row from the corresponding SHOW CREATE statement */
     public function createTable(array $row): string;
+
+    /** @param array<string, mixed> $row Row from the corresponding SHOW CREATE statement */
     public function createTrigger(array $row): string;
+
+    /** @param array<string, mixed> $row Row from the corresponding SHOW CREATE statement */
     public function createView(array $row): string;
+
     public function databases(string $databaseName): string;
     public function dropTable(string $tableName): string;
     public function dropView(string $viewName): string;
@@ -23,7 +36,13 @@ interface TypeAdapterInterface
     public function getDatabaseHeader(string $databaseName): string;
     public function getVersion(): string;
     public function lockTable(string $tableName): void;
+
+    /**
+     * @param array<string, mixed> $colType Row from "SHOW COLUMNS FROM tableName"
+     * @return array<string, mixed> Column metadata (type, is_numeric, is_blob, is_virtual, ...)
+     */
     public function parseColumnType(array $colType): array;
+
     public function restoreParameters(): string;
     public function setupTransaction(): string;
     public function showColumns(string $tableName): string;

--- a/src/TypeAdapter/TypeAdapterMysql.php
+++ b/src/TypeAdapter/TypeAdapterMysql.php
@@ -11,6 +11,7 @@ class TypeAdapterMysql implements TypeAdapterInterface
     const DEFINER_RE = 'DEFINER=`(?:[^`]|``)*`@`(?:[^`]|``)*`';
 
     // Numerical Mysql types
+    /** @var array<string, string[]> */
     public array $mysqlTypes = [
         'numerical' => [
             'bit',
@@ -151,7 +152,7 @@ class TypeAdapterMysql implements TypeAdapterInterface
             '/^(CREATE(?:\s+ALGORITHM=(?:UNDEFINED|MERGE|TEMPTABLE))?)\s+('
             .self::DEFINER_RE.'(?:\s+SQL SECURITY DEFINER|INVOKER)?)?\s+(VIEW .+)$/',
             '/*!50001 \1 */'.PHP_EOL.$definerStr.'/*!50001 \3 */',
-            $viewStmt,
+            (string) $viewStmt,
             1
         )) {
             $viewStmt = $viewStmtReplaced;
@@ -177,7 +178,7 @@ class TypeAdapterMysql implements TypeAdapterInterface
         if ($triggerStmtReplaced = preg_replace(
             '/^(CREATE)\s+('.self::DEFINER_RE.')?\s+(TRIGGER\s.*)$/s',
             '/*!50003 \1*/ '.$definerStr.'/*!50003 \3 */',
-            $triggerStmt,
+            (string) $triggerStmt,
             1
         )) {
             $triggerStmt = $triggerStmtReplaced;
@@ -299,7 +300,7 @@ class TypeAdapterMysql implements TypeAdapterInterface
         if ($eventStmtReplaced = preg_replace(
             '/^(CREATE)\s+('.self::DEFINER_RE.')?\s+(EVENT .*)$/',
             '/*!50106 \1*/ '.$definerStr.'/*!50106 \3 */',
-            $eventStmt,
+            (string) $eventStmt,
             1
         )) {
             $eventStmt = $eventStmtReplaced;
@@ -492,8 +493,8 @@ class TypeAdapterMysql implements TypeAdapterInterface
      * Decode column metadata and fill info structure.
      * type, is_numeric and is_blob will always be available.
      *
-     * @param array $colType Array returned from "SHOW COLUMNS FROM tableName"
-     * @return array
+     * @param array<string, mixed> $colType Array returned from "SHOW COLUMNS FROM tableName"
+     * @return array<string, mixed>
      */
     public function parseColumnType(array $colType): array
     {

--- a/tests/CompressGzipTest.php
+++ b/tests/CompressGzipTest.php
@@ -26,6 +26,9 @@ class CompressGzipTest extends TestCase
         $this->assertSame($level, $this->getLevel($gzip));
     }
 
+    /**
+     * @return array<int, array{int}>
+     */
     public static function validLevelProvider(): array
     {
         return [[1], [5], [9]];
@@ -38,6 +41,9 @@ class CompressGzipTest extends TestCase
         $this->assertSame(0, $this->getLevel($gzip));
     }
 
+    /**
+     * @return array<int, array{int}>
+     */
     public static function outOfRangeLevelProvider(): array
     {
         return [[0], [10], [100]];

--- a/tests/DatabaseConnectorTest.php
+++ b/tests/DatabaseConnectorTest.php
@@ -55,7 +55,7 @@ class DatabaseConnectorTest extends TestCase
         new DatabaseConnector('mysql:host=localhost', 'user', 'pass');
     }
 
-    private function getPrivate(object $object, string $var)
+    private function getPrivate(object $object, string $var): mixed
     {
         $refl = new \ReflectionProperty($object::class, $var);
         return $refl->getValue($object);

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -101,13 +101,13 @@ class MysqldumpTest extends TestCase
         $this->assertFalse($dump->getTableLimit('table_with_invalid_range_limit3'));
     }
 
-    private function getPrivate(Mysqldump $dump, $var)
+    private function getPrivate(Mysqldump $dump, string $var): mixed
     {
         $reflectionProperty = new \ReflectionProperty(Mysqldump::class, $var);
         return $reflectionProperty->getValue($dump);
     }
 
-    private function getPrivateFromObject($object, $var)
+    private function getPrivateFromObject(object $object, string $var): mixed
     {
         $reflectionProperty = new \ReflectionProperty($object::class, $var);
         return $reflectionProperty->getValue($object);


### PR DESCRIPTION
## What

Raises PHPStan from level 5 to level 6 and fixes all 71 errors it surfaced — all missing type declarations, no logic changes.

- Add array value types (PHPDoc) across `src/` and `tests/`: settings arrays, table lists, the ConfigValidator metadata cache shape, `Mysqldump` properties and helpers.
- Type the `$row`/`$colType` params once on `TypeAdapterInterface`; `TypeAdapterMysql` and the test `FakeTypeAdapter` inherit the PHPDocs.
- Type the resource-holding properties in `Compress/*` as `@var resource|false` (streams have no native type) and the deflate context as `@var \DeflateContext|false`.
- Type the reflection helpers and data providers in tests.
- Add explicit `(string)` casts on three `preg_replace()` calls in `TypeAdapterMysql` — required by Rector (blocking in CI) once the row params became `array<string, mixed>`, and consistent with casts already used in the file.
- Add `--memory-limit=256M` to the CI PHPStan step: a cold-cache level 6 run crashes under PHP's default 128M limit.
- Update stale CLAUDE.md references (said level 4; config was at 5).

## Why

Stricter static analysis catches missing/wrong types at CI time; level 6 is the next step on the roadmap toward stronger typing in 3.x.

## Testing

- `vendor/bin/phpstan --memory-limit=256M` — no errors (verified on a cold result cache)
- `vendor/bin/rector process --dry-run` — clean
- `vendor/bin/phpunit` — 64 tests, 150 assertions, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)