### PR TITLE
feat: add custom exception hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,11 @@ src/
 │   ├── DefaultValue.php       # Default values with descriptions
 │   ├── Injectable.php         # DI marker
 │   └── ValidatesValue.php     # Validation marker
+├── Exception/                 # Custom exception hierarchy
+│   ├── MysqldumpException.php # Base class (extends native Exception)
+│   ├── ConnectionException.php    # DSN parsing / PDO connection failures
+│   ├── ConfigurationException.php # Invalid or conflicting dump settings
+│   └── DumpException.php      # I/O and server errors during the dump
 ├── Compress/                  # Compression implementations
 │   ├── CompressInterface.php  # Common interface
 │   ├── CompressMethod.php     # Enum of compression methods
@@ -226,9 +231,11 @@ $dump->getAdapter(PDO $conn);
 ```
 
 ### Error Handling
-- Uses standard `Exception` class (no custom hierarchy yet)
-- PDO connection errors caught and re-thrown with context
-- Validation errors from `ConfigValidator` have specific messages
+- Custom exception hierarchy in `src/Exception/`: `ConnectionException`,
+  `ConfigurationException` and `DumpException` extend `MysqldumpException`,
+  which extends the native `Exception` (so `catch (Exception)` still works)
+- PDO connection errors caught and re-thrown as `ConnectionException` with context
+- Validation errors from `ConfigValidator` throw `ConfigurationException` with specific messages
 
 ## Common Tasks
 
@@ -260,7 +267,7 @@ $dump->getAdapter(PDO $conn);
 | `phpstan.dist.neon` | Static analysis configuration |
 | `rector.php` | Code modernization rules |
 | `.github/workflows/tests.yml` | CI/CD pipeline |
-| `docs/tasks.md` | Improvement roadmap (refactoring direction, e.g. planned custom exceptions) |
+| `docs/tasks.md` | Improvement roadmap (checkbox task list) |
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ from 2.x. The following changes may require action:
 - **`compress-level` is validated per method.** Levels up to the method maximum are accepted
   (Gzip 1-9, Lz4 1-12, Zstd 1-22) where 2.x rejected everything above 9, and a level above the
   method maximum now throws with a method-specific message.
+- **Exceptions are now typed.** The library throws subclasses of
+  `Druidfi\Mysqldump\Exception\MysqldumpException` instead of bare `Exception`. No action is
+  needed — the base class extends `Exception`, so existing `catch (\Exception $e)` blocks keep
+  working — but you can now catch more specific types, see [Error handling](#error-handling).
 
 Also fixed in 3.x with no action needed: 2.x settings validation rejected the `Zstd`, `Lz4` and
 `Gzipstream` compression methods due to a mismatch between the allowed values and the factory;
@@ -80,7 +84,7 @@ composer require druidfi/mysqldump-php
 try {
     $dump = new \Druidfi\Mysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
     $dump->start('storage/work/dump.sql');
-} catch (\Exception $e) {
+} catch (\Druidfi\Mysqldump\Exception\MysqldumpException $e) {
     echo 'mysqldump-php error: ' . $e->getMessage();
 }
 ```
@@ -88,6 +92,21 @@ try {
 The sections below cover the most common use cases. All configuration options are listed under
 [Dump Settings](#dump-settings), and the [Tests](#tests) section describes how the output is
 compared against native `mysqldump`.
+
+## Error handling
+
+All exceptions thrown by the library extend `Druidfi\Mysqldump\Exception\MysqldumpException`,
+which itself extends the native `Exception`. Catch the base class to handle any library error,
+or a subclass to react to a specific failure:
+
+- `ConnectionException` — the database connection could not be established: malformed DSN
+  string or a PDO connection failure. Thrown from the constructor (DSN parsing) and from
+  `start()` (connecting).
+- `ConfigurationException` — invalid dump settings: unknown options, values failing validation,
+  conflicting options (e.g. `replace` + `insert-ignore`), include-tables that do not exist in
+  the database, or a compression method whose PHP extension is not installed.
+- `DumpException` — the dump itself failed: output file not writable, a write error (e.g. disk
+  full), or an unexpected result from the server while reading object structures.
 
 ## Changing values when exporting
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -26,10 +26,12 @@ codebase; items that are done are kept checked for history.
          gain nothing from persistence and recycled handles can carry over session state;
          opt back in via the `pdoOptions` constructor argument
 
-3. [ ] Improve error handling:
-   - [ ] Create custom exception classes (e.g. `ConnectionException`, `ConfigurationException`,
-         `DumpException`) extending a common `MysqldumpException`; everything currently throws bare `Exception`
-   - [ ] Implement a proper exception hierarchy and document which methods throw what
+3. [x] Improve error handling:
+   - [x] Create custom exception classes (`ConnectionException`, `ConfigurationException`,
+         `DumpException`) extending a common `MysqldumpException` in `src/Exception/`;
+         the base extends native `Exception` so existing catch blocks keep working
+   - [x] Implement a proper exception hierarchy and document which methods throw what
+         (`@throws` docblocks updated throughout; README "Error handling" section added)
 
 4. [ ] Implement interfaces for major components:
    - [x] Create a DumperInterface for different dumper implementations
@@ -99,8 +101,8 @@ codebase; items that are done are kept checked for history.
 
 ## Documentation Improvements
 
-12. [ ] Improve code documentation:
-    - [ ] Document `@throws` consistently once custom exceptions exist (task 3)
+12. [x] Improve code documentation:
+    - [x] Document `@throws` consistently with the custom exception classes from task 3
     - [x] Remove stale PHPDoc — the `getDatabaseStructure*` docblocks claiming to fill a
           non-existent `$this->tables` array went away with the methods themselves (task 1)
 

--- a/src/Compress/CompressBzip2.php
+++ b/src/Compress/CompressBzip2.php
@@ -2,7 +2,8 @@
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
+use Druidfi\Mysqldump\Exception\DumpException;
 
 class CompressBzip2 implements CompressInterface
 {
@@ -10,38 +11,38 @@ class CompressBzip2 implements CompressInterface
     private $fileHandler;
 
     /**
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public function __construct()
     {
         if (!function_exists('bzopen')) {
-            throw new Exception('Compression is enabled, but bzip2 lib is not installed or configured properly');
+            throw new ConfigurationException('Compression is enabled, but bzip2 lib is not installed or configured properly');
         }
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function open(string $filename): bool
     {
         $this->fileHandler = bzopen($filename, 'w');
 
         if (false === $this->fileHandler) {
-            throw new Exception('Output file is not writable');
+            throw new DumpException('Output file is not writable');
         }
 
         return true;
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function write(string $str): int
     {
         $bytesWritten = bzwrite($this->fileHandler, $str);
 
         if (false === $bytesWritten) {
-            throw new Exception('Writing to file failed! Probably, there is no more free space left?');
+            throw new DumpException('Writing to file failed! Probably, there is no more free space left?');
         }
 
         return $bytesWritten;

--- a/src/Compress/CompressGzip.php
+++ b/src/Compress/CompressGzip.php
@@ -2,7 +2,8 @@
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
+use Druidfi\Mysqldump\Exception\DumpException;
 
 class CompressGzip implements CompressInterface
 {
@@ -11,12 +12,12 @@ class CompressGzip implements CompressInterface
     private readonly int $level;
 
     /**
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public function __construct(int $level = 0)
     {
         if (!function_exists('gzopen')) {
-            throw new Exception('Compression is enabled, but gzip lib is not installed or configured properly');
+            throw new ConfigurationException('Compression is enabled, but gzip lib is not installed or configured properly');
         }
 
         // gzip level: 0 = default, 1-9 = fast to best
@@ -24,7 +25,7 @@ class CompressGzip implements CompressInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function open(string $filename): bool
     {
@@ -32,21 +33,21 @@ class CompressGzip implements CompressInterface
         $this->fileHandler = gzopen($filename, $mode);
 
         if (false === $this->fileHandler) {
-            throw new Exception('Output file is not writable');
+            throw new DumpException('Output file is not writable');
         }
 
         return true;
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function write(string $str): int
     {
         $bytesWritten = gzwrite($this->fileHandler, $str);
 
         if (false === $bytesWritten) {
-            throw new Exception('Writing to file failed! Probably, there is no more free space left?');
+            throw new DumpException('Writing to file failed! Probably, there is no more free space left?');
         }
 
         return $bytesWritten;

--- a/src/Compress/CompressGzipstream.php
+++ b/src/Compress/CompressGzipstream.php
@@ -2,7 +2,7 @@
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\DumpException;
 
 class CompressGzipstream implements CompressInterface
 {
@@ -12,14 +12,14 @@ class CompressGzipstream implements CompressInterface
     private $compressContext;
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function open(string $filename): bool
     {
         $this->fileHandler = fopen($filename, 'wb');
 
         if (false === $this->fileHandler) {
-            throw new Exception('Output file is not writable');
+            throw new DumpException('Output file is not writable');
         }
 
         $this->compressContext = deflate_init(ZLIB_ENCODING_GZIP, ['level' => 9]);
@@ -28,14 +28,14 @@ class CompressGzipstream implements CompressInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function write(string $str): int
     {
         $bytesWritten = fwrite($this->fileHandler, deflate_add($this->compressContext, $str, ZLIB_NO_FLUSH));
 
         if (false === $bytesWritten) {
-            throw new Exception('Writing to file failed! Probably, there is no more free space left?');
+            throw new DumpException('Writing to file failed! Probably, there is no more free space left?');
         }
 
         return $bytesWritten;

--- a/src/Compress/CompressLz4.php
+++ b/src/Compress/CompressLz4.php
@@ -2,7 +2,8 @@
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
+use Druidfi\Mysqldump\Exception\DumpException;
 
 class CompressLz4 implements CompressInterface
 {
@@ -11,12 +12,12 @@ class CompressLz4 implements CompressInterface
     private readonly int $compressionLevel;
 
     /**
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public function __construct(int $compressionLevel = 1)
     {
         if (!extension_loaded('lz4')) {
-            throw new Exception('Compression is enabled, but lz4 extension is not installed or configured properly');
+            throw new ConfigurationException('Compression is enabled, but lz4 extension is not installed or configured properly');
         }
         
         // Ensure compression level is within valid range (1-12 for LZ4)
@@ -24,35 +25,35 @@ class CompressLz4 implements CompressInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function open(string $filename): bool
     {
         $this->fileHandler = fopen($filename, 'wb');
 
         if (false === $this->fileHandler) {
-            throw new Exception('Output file is not writable');
+            throw new DumpException('Output file is not writable');
         }
 
         // Create an LZ4 compression context
         $this->fileHandler = lz4_compress_open($this->fileHandler, $this->compressionLevel);
 
         if (false === $this->fileHandler) {
-            throw new Exception('Failed to initialize LZ4 compression');
+            throw new DumpException('Failed to initialize LZ4 compression');
         }
 
         return true;
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function write(string $str): int
     {
         $bytesWritten = lz4_compress_write($this->fileHandler, $str);
 
         if (false === $bytesWritten) {
-            throw new Exception('Writing to file failed! Probably, there is no more free space left?');
+            throw new DumpException('Writing to file failed! Probably, there is no more free space left?');
         }
 
         return $bytesWritten;

--- a/src/Compress/CompressManagerFactory.php
+++ b/src/Compress/CompressManagerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 
 abstract class CompressManagerFactory
 {
@@ -17,7 +17,7 @@ abstract class CompressManagerFactory
     public const string LZ4 = 'Lz4';
 
     /**
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public static function create(string $method, int $level = 0): CompressInterface
     {

--- a/src/Compress/CompressMethod.php
+++ b/src/Compress/CompressMethod.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 
 /**
  * Available compression methods for dump output.
@@ -21,14 +21,14 @@ enum CompressMethod: string
     /**
      * Resolve a compression method from user input, case-insensitively.
      *
-     * @throws Exception when the method is not defined
+     * @throws ConfigurationException when the method is not defined
      */
     public static function fromName(string $method): self
     {
         $normalized = ucfirst(strtolower($method));
 
         return self::tryFrom($normalized)
-            ?? throw new Exception("Compression method ($normalized) is not defined yet");
+            ?? throw new ConfigurationException("Compression method ($normalized) is not defined yet");
     }
 
     /**
@@ -49,7 +49,7 @@ enum CompressMethod: string
      * Create the compressor for this method. A level of 0 means the
      * compressor's own default level (Zstd defaults to 3, Lz4 to 1).
      *
-     * @throws Exception when a required extension is missing
+     * @throws ConfigurationException when a required extension is missing
      */
     public function compressor(int $level = 0): CompressInterface
     {

--- a/src/Compress/CompressNone.php
+++ b/src/Compress/CompressNone.php
@@ -2,7 +2,7 @@
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\DumpException;
 
 class CompressNone implements CompressInterface
 {
@@ -10,28 +10,28 @@ class CompressNone implements CompressInterface
     private $fileHandler;
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function open(string $filename): bool
     {
         $this->fileHandler = fopen($filename, 'wb');
 
         if (false === $this->fileHandler) {
-            throw new Exception('Output file is not writable');
+            throw new DumpException('Output file is not writable');
         }
 
         return true;
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function write(string $str): int
     {
         $bytesWritten = fwrite($this->fileHandler, $str);
 
         if (false === $bytesWritten) {
-            throw new Exception('Writing to file failed! Probably, there is no more free space left?');
+            throw new DumpException('Writing to file failed! Probably, there is no more free space left?');
         }
 
         return $bytesWritten;

--- a/src/Compress/CompressZstd.php
+++ b/src/Compress/CompressZstd.php
@@ -2,7 +2,8 @@
 
 namespace Druidfi\Mysqldump\Compress;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
+use Druidfi\Mysqldump\Exception\DumpException;
 
 class CompressZstd implements CompressInterface
 {
@@ -11,12 +12,12 @@ class CompressZstd implements CompressInterface
     private readonly int $compressionLevel;
 
     /**
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public function __construct(int $compressionLevel = 3)
     {
         if (!extension_loaded('zstd')) {
-            throw new Exception('Compression is enabled, but zstd extension is not installed or configured properly');
+            throw new ConfigurationException('Compression is enabled, but zstd extension is not installed or configured properly');
         }
         
         // Ensure compression level is within valid range (1-22 for zstd)
@@ -24,14 +25,14 @@ class CompressZstd implements CompressInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function open(string $filename): bool
     {
         $this->fileHandler = fopen($filename, 'wb');
 
         if (false === $this->fileHandler) {
-            throw new Exception('Output file is not writable');
+            throw new DumpException('Output file is not writable');
         }
 
         // Create a zstd compression context with the specified compression level
@@ -41,14 +42,14 @@ class CompressZstd implements CompressInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function write(string $str): int
     {
         $bytesWritten = zstd_compress_stream_update($this->fileHandler, $str);
 
         if (false === $bytesWritten) {
-            throw new Exception('Writing to file failed! Probably, there is no more free space left?');
+            throw new DumpException('Writing to file failed! Probably, there is no more free space left?');
         }
 
         return $bytesWritten;

--- a/src/ConfigValidator.php
+++ b/src/ConfigValidator.php
@@ -6,7 +6,7 @@ namespace Druidfi\Mysqldump;
 use Deprecated;
 use Druidfi\Mysqldump\Attribute\Constraint;
 use Druidfi\Mysqldump\Attribute\DefaultValue;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 use ReflectionClass;
 use ReflectionClassConstant;
 
@@ -103,7 +103,7 @@ class ConfigValidator
     /**
      * Validate a configuration option value against its Constraint attribute.
      * 
-     * @throws Exception if validation fails
+     * @throws ConfigurationException if validation fails
      */
     public static function validate(string $optionName, mixed $value): void
     {
@@ -124,7 +124,7 @@ class ConfigValidator
             if (!is_string($value) || $constraint->enum::tryFrom($value) === null) {
                 $allowed = implode(', ', array_column($constraint->enum::cases(), 'value'));
                 $message = $constraint->message ?? "Invalid value for '{$optionName}'. Allowed: {$allowed}";
-                throw new Exception($message);
+                throw new ConfigurationException($message);
             }
         }
 
@@ -133,7 +133,7 @@ class ConfigValidator
             if (!in_array($value, $constraint->allowedValues, true)) {
                 $allowed = implode(', ', $constraint->allowedValues);
                 $message = $constraint->message ?? "Invalid value for '{$optionName}'. Allowed: {$allowed}";
-                throw new Exception($message);
+                throw new ConfigurationException($message);
             }
         }
 
@@ -141,12 +141,12 @@ class ConfigValidator
         if (is_numeric($value)) {
             if ($constraint->min !== null && $value < $constraint->min) {
                 $message = $constraint->message ?? "Value for '{$optionName}' must be at least {$constraint->min}";
-                throw new Exception($message);
+                throw new ConfigurationException($message);
             }
 
             if ($constraint->max !== null && $value > $constraint->max) {
                 $message = $constraint->message ?? "Value for '{$optionName}' must be at most {$constraint->max}";
-                throw new Exception($message);
+                throw new ConfigurationException($message);
             }
         }
 
@@ -154,7 +154,7 @@ class ConfigValidator
         if ($constraint->pattern !== null && is_string($value)) {
             if (!preg_match($constraint->pattern, $value)) {
                 $message = $constraint->message ?? "Value for '{$optionName}' does not match required pattern";
-                throw new Exception($message);
+                throw new ConfigurationException($message);
             }
         }
     }
@@ -188,7 +188,7 @@ class ConfigValidator
      * Validate all settings in a configuration array.
      *
      * @param array<string, mixed> $settings
-     * @throws Exception if any validation fails
+     * @throws ConfigurationException if any validation fails
      */
     public static function validateAll(array $settings): void
     {

--- a/src/DatabaseConnector.php
+++ b/src/DatabaseConnector.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Druidfi\Mysqldump;
 
-use Exception;
+use Druidfi\Mysqldump\Exception\ConnectionException;
 use PDO;
 use PDOException;
 use SensitiveParameter;
@@ -28,7 +28,7 @@ class DatabaseConnector
      * @param string|null $user SQL account username
      * @param string|null $pass SQL account password
      * @param array<int, mixed> $pdoOptions PDO configured attributes
-     * @throws Exception
+     * @throws ConnectionException
      */
     public function __construct(
         private readonly string $dsn = '',
@@ -48,18 +48,18 @@ class DatabaseConnector
      *   mysql:unix_socket=/tmp/mysql.sock;dbname=testdb
      *
      * @param string $dsn dsn string to parse
-     * @throws Exception
+     * @throws ConnectionException
      */
     private function parseDsn(string $dsn): void
     {
         if (empty($dsn) || !($pos = strpos($dsn, ':'))) {
-            throw new Exception('Empty DSN string');
+            throw new ConnectionException('Empty DSN string');
         }
 
         $dbType = strtolower(substr($dsn, 0, $pos));
 
         if (empty($dbType)) {
-            throw new Exception('Missing database type from DSN string');
+            throw new ConnectionException('Missing database type from DSN string');
         }
 
         $data = [];
@@ -72,11 +72,11 @@ class DatabaseConnector
         }
 
         if (empty($data['host']) && empty($data['unix_socket'])) {
-            throw new Exception('Missing host from DSN string');
+            throw new ConnectionException('Missing host from DSN string');
         }
 
         if (empty($data['dbname'])) {
-            throw new Exception('Missing database name from DSN string');
+            throw new ConnectionException('Missing database name from DSN string');
         }
 
         $this->host = (!empty($data['host'])) ? $data['host'] : $data['unix_socket'];
@@ -87,7 +87,7 @@ class DatabaseConnector
      * Connect to the database with PDO.
      *
      * @return PDO The PDO connection
-     * @throws Exception
+     * @throws ConnectionException
      */
     public function connect(): PDO
     {
@@ -123,7 +123,7 @@ class DatabaseConnector
             $this->conn = new PDO($this->dsn, $this->user, $this->pass, $options);
         } catch (PDOException $e) {
             $message = sprintf("Connection to %s failed with message: %s", $this->host, $e->getMessage());
-            throw new Exception($message);
+            throw new ConnectionException($message);
         }
 
         return $this->conn;

--- a/src/DumpSettings.php
+++ b/src/DumpSettings.php
@@ -5,7 +5,7 @@ namespace Druidfi\Mysqldump;
 
 use Druidfi\Mysqldump\Compress\CompressManagerFactory;
 use Druidfi\Mysqldump\Compress\CompressMethod;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 
 class DumpSettings
 {
@@ -57,7 +57,7 @@ class DumpSettings
 
     /**
      * @param array<string, mixed> $settings
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public function __construct(array $settings)
     {
@@ -90,15 +90,15 @@ class DumpSettings
         $diff = array_diff(array_keys($this->settings), array_keys(self::$defaults));
 
         if (count($diff) > 0) {
-            throw new Exception("Unexpected value in dumpSettings: (" . implode(",", $diff) . ")");
+            throw new ConfigurationException("Unexpected value in dumpSettings: (" . implode(",", $diff) . ")");
         }
 
         if (!is_array($this->settings['include-tables']) || !is_array($this->settings['exclude-tables'])) {
-            throw new Exception('Include-tables and exclude-tables should be arrays');
+            throw new ConfigurationException('Include-tables and exclude-tables should be arrays');
         }
 
         if ($this->settings['replace'] && $this->settings['insert-ignore']) {
-            throw new Exception('Cannot use both replace and insert-ignore options simultaneously');
+            throw new ConfigurationException('Cannot use both replace and insert-ignore options simultaneously');
         }
 
         // Method-specific upper bound: Gzip 1-9, Lz4 1-12, Zstd 1-22.
@@ -107,7 +107,7 @@ class DumpSettings
             $method = CompressMethod::fromName($this->getCompressMethod());
             $maxLevel = $method->maxLevel();
             if ($maxLevel !== null && $level > $maxLevel) {
-                throw new Exception(
+                throw new ConfigurationException(
                     sprintf('Compression level %d is out of range for %s (1-%d)', $level, $method->value, $maxLevel)
                 );
             }

--- a/src/DumpWriter.php
+++ b/src/DumpWriter.php
@@ -5,7 +5,8 @@ namespace Druidfi\Mysqldump;
 
 use Druidfi\Mysqldump\Compress\CompressInterface;
 use Druidfi\Mysqldump\Compress\CompressManagerFactory;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
+use Druidfi\Mysqldump\Exception\DumpException;
 
 /**
  * Class DumpWriter
@@ -29,7 +30,8 @@ class DumpWriter
      * Initialize the writer with the specified destination.
      *
      * @param string $destination Path to the output file or php://stdout
-     * @throws Exception
+     * @throws ConfigurationException when the compression method is unavailable
+     * @throws DumpException when the destination cannot be opened
      */
     public function initialize(string $destination): void
     {
@@ -48,7 +50,7 @@ class DumpWriter
      *
      * @param string $data Data to write
      * @return int Number of bytes written
-     * @throws Exception
+     * @throws DumpException
      */
     public function write(string $data): int
     {

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump\Exception;
+
+/**
+ * Thrown when dump settings are invalid: unknown options, values that
+ * fail constraint validation, conflicting options, include-tables that
+ * do not exist, or compression methods whose extension is not installed.
+ */
+class ConfigurationException extends MysqldumpException
+{
+}

--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump\Exception;
+
+/**
+ * Thrown when the database connection cannot be established:
+ * malformed DSN strings or PDO connection failures.
+ */
+class ConnectionException extends MysqldumpException
+{
+}

--- a/src/Exception/DumpException.php
+++ b/src/Exception/DumpException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump\Exception;
+
+/**
+ * Thrown when the dump itself fails: output not writable, write
+ * errors (e.g. disk full), or unexpected results from the server
+ * while reading database object structures.
+ */
+class DumpException extends MysqldumpException
+{
+}

--- a/src/Exception/MysqldumpException.php
+++ b/src/Exception/MysqldumpException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump\Exception;
+
+use Exception;
+
+/**
+ * Base exception for all errors thrown by mysqldump-php.
+ *
+ * Extends the native Exception so existing catch (Exception) blocks
+ * keep working; catch this class to handle any library error.
+ */
+class MysqldumpException extends Exception
+{
+}

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -20,7 +20,10 @@ use Closure;
 use Druidfi\Mysqldump\TypeAdapter\TypeAdapterInterface;
 use Druidfi\Mysqldump\TypeAdapter\TypeAdapterMysql;
 use Druidfi\Mysqldump\ObjectDumper as ObjectDumper;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
+use Druidfi\Mysqldump\Exception\ConnectionException;
+use Druidfi\Mysqldump\Exception\DumpException;
+use Druidfi\Mysqldump\Exception\MysqldumpException;
 use PDO;
 
 class Mysqldump
@@ -59,7 +62,7 @@ class Mysqldump
      * @param string|null $pass SQL account password
      * @param array<string, mixed> $settings SQL database settings
      * @param array<int, mixed> $pdoOptions PDO configured attributes
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public function __construct(
         string  $dsn = '',
@@ -78,7 +81,7 @@ class Mysqldump
     /**
      * Connect with PDO using the DatabaseConnector.
      *
-     * @throws Exception
+     * @throws ConnectionException
      */
     private function connect(): void
     {
@@ -113,7 +116,7 @@ class Mysqldump
      * Primary function, triggers dumping.
      *
      * @param string|null $filename Name of file to write sql dump to
-     * @throws Exception
+     * @throws MysqldumpException
      */
     public function start(?string $filename = ''): void
     {
@@ -288,7 +291,7 @@ class Mysqldump
         $missingTables = array_diff($includedTables, $existingTables);
 
         if (!empty($missingTables)) {
-            throw new Exception(sprintf("Table '%s' not found in database", implode(',', $missingTables)));
+            throw new ConfigurationException(sprintf("Table '%s' not found in database", implode(',', $missingTables)));
         }
     }
 
@@ -614,7 +617,7 @@ class Mysqldump
      * Event structure extractor.
      *
      * @param string $eventName Name of event to export
-     * @throws Exception
+     * @throws DumpException
      */
     private function getEventStructure(string $eventName): void
     {
@@ -975,13 +978,13 @@ class Mysqldump
      * Set the TypeAdapter class used by this instance.
      *
      * @param class-string $adapterClassName Must implement TypeAdapterInterface (validated at runtime)
-     * @throws Exception
+     * @throws ConfigurationException
      */
     public function addTypeAdapter(string $adapterClassName): void
     {
         if (!is_a($adapterClassName, TypeAdapterInterface::class, true)) {
             $message = sprintf('Adapter %s is not instance of %s', $adapterClassName, TypeAdapterInterface::class);
-            throw new Exception($message);
+            throw new ConfigurationException($message);
         }
 
         $this->adapterClass = $adapterClassName;

--- a/src/TypeAdapter/TypeAdapterMysql.php
+++ b/src/TypeAdapter/TypeAdapterMysql.php
@@ -3,7 +3,7 @@
 namespace Druidfi\Mysqldump\TypeAdapter;
 
 use Druidfi\Mysqldump\DumpSettings;
-use Exception;
+use Druidfi\Mysqldump\Exception\DumpException;
 use PDO;
 
 class TypeAdapterMysql implements TypeAdapterInterface
@@ -107,12 +107,12 @@ class TypeAdapterMysql implements TypeAdapterInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function createTable(array $row): string
     {
         if (!isset($row['Create Table'])) {
-            throw new Exception("Error getting table code, unknown output");
+            throw new DumpException("Error getting table code, unknown output");
         }
 
         $createTable = $row['Create Table'];
@@ -134,14 +134,14 @@ class TypeAdapterMysql implements TypeAdapterInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function createView(array $row): string
     {
         $ret = "";
 
         if (!isset($row['Create View'])) {
-            throw new Exception("Error getting view structure, unknown output");
+            throw new DumpException("Error getting view structure, unknown output");
         }
 
         $viewStmt = $row['Create View'];
@@ -164,13 +164,13 @@ class TypeAdapterMysql implements TypeAdapterInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function createTrigger(array $row): string
     {
         $ret = "";
         if (!isset($row['SQL Original Statement'])) {
-            throw new Exception("Error getting trigger code, unknown output");
+            throw new DumpException("Error getting trigger code, unknown output");
         }
 
         $triggerStmt = $row['SQL Original Statement'];
@@ -192,14 +192,14 @@ class TypeAdapterMysql implements TypeAdapterInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function createProcedure(array $row): string
     {
         $ret = "";
 
         if (!isset($row['Create Procedure'])) {
-            throw new Exception("Error getting procedure code, unknown output. ".
+            throw new DumpException("Error getting procedure code, unknown output. ".
                 "Please check 'https://bugs.mysql.com/bug.php?id=14564'");
         }
 
@@ -229,14 +229,14 @@ class TypeAdapterMysql implements TypeAdapterInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function createFunction(array $row): string
     {
         $ret = "";
 
         if (!isset($row['Create Function'])) {
-            throw new Exception("Error getting function code, unknown output. ".
+            throw new DumpException("Error getting function code, unknown output. ".
                 "Please check 'https://bugs.mysql.com/bug.php?id=14564'");
         }
         $functionStmt = $row['Create Function'];
@@ -281,14 +281,14 @@ class TypeAdapterMysql implements TypeAdapterInterface
     }
 
     /**
-     * @throws Exception
+     * @throws DumpException
      */
     public function createEvent(array $row): string
     {
         $ret = "";
 
         if (!isset($row['Create Event'])) {
-            throw new Exception("Error getting event code, unknown output. ".
+            throw new DumpException("Error getting event code, unknown output. ".
                 "Please check 'https://stackoverflow.com/questions/10853826/mysql-5-5-create-event-gives-syntax-error'");
         }
 

--- a/tests/CompressManagerFactoryTest.php
+++ b/tests/CompressManagerFactoryTest.php
@@ -9,7 +9,7 @@ use Druidfi\Mysqldump\Compress\CompressManagerFactory;
 use Druidfi\Mysqldump\Compress\CompressNone;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 
 #[CoversClass(CompressManagerFactory::class)]
 class CompressManagerFactoryTest extends TestCase
@@ -28,7 +28,7 @@ class CompressManagerFactoryTest extends TestCase
             try {
                 $instance = CompressManagerFactory::create($method, 3);
                 $this->assertInstanceOf($expectedClass, $instance, "Factory did not return $expectedClass for $method");
-            } catch (Exception $e) {
+            } catch (ConfigurationException $e) {
                 // If environment lacks required functions, skip gracefully
                 $this->markTestSkipped("Skipping $method due to missing extension: {$e->getMessage()}");
             }
@@ -37,7 +37,7 @@ class CompressManagerFactoryTest extends TestCase
 
     public function testCreateInvalidMethodThrows(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Compression method (Invalid) is not defined yet');
         CompressManagerFactory::create('Invalid');
     }

--- a/tests/ConfigValidatorTest.php
+++ b/tests/ConfigValidatorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Druidfi\Mysqldump\Tests;
 
 use Druidfi\Mysqldump\ConfigValidator;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -48,7 +48,7 @@ class ConfigValidatorTest extends TestCase
 
     public function testValidateRejectsInvalidCompressValue(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Must be a valid compression method');
         
         ConfigValidator::validate('compress', 'InvalidCompression');
@@ -63,7 +63,7 @@ class ConfigValidatorTest extends TestCase
 
     public function testValidateRejectsCompressionLevelTooLow(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Compression level must be between 0 and 22');
 
         ConfigValidator::validate('compress-level', -1);
@@ -71,7 +71,7 @@ class ConfigValidatorTest extends TestCase
 
     public function testValidateRejectsCompressionLevelTooHigh(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Compression level must be between 0 and 22');
 
         ConfigValidator::validate('compress-level', 23);
@@ -86,7 +86,7 @@ class ConfigValidatorTest extends TestCase
 
     public function testValidateRejectsInvalidCharacterSet(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Must be utf8 or utf8mb4');
         
         ConfigValidator::validate('default-character-set', 'latin1');
@@ -129,7 +129,7 @@ class ConfigValidatorTest extends TestCase
             'compress' => 'InvalidMethod',
         ];
 
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Must be a valid compression method');
         
         ConfigValidator::validateAll($settings);
@@ -145,7 +145,7 @@ class ConfigValidatorTest extends TestCase
 
     public function testValidateNetBufferLengthMinConstraint(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Net buffer length must be at least 1024');
         
         ConfigValidator::validate('net_buffer_length', 512);

--- a/tests/DatabaseConnectorTest.php
+++ b/tests/DatabaseConnectorTest.php
@@ -5,7 +5,7 @@ namespace Druidfi\Mysqldump\Tests;
 use Druidfi\Mysqldump\DatabaseConnector;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConnectionException;
 
 #[CoversClass(DatabaseConnector::class)]
 class DatabaseConnectorTest extends TestCase
@@ -28,14 +28,14 @@ class DatabaseConnectorTest extends TestCase
 
     public function testEmptyDsnThrows(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConnectionException::class);
         $this->expectExceptionMessage('Empty DSN string');
         new DatabaseConnector('', 'user', 'pass');
     }
 
     public function testMissingDbTypeThrows(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConnectionException::class);
         // Due to current implementation treating colon at position 0 as empty DSN
         $this->expectExceptionMessage('Empty DSN string');
         new DatabaseConnector(':host=localhost;dbname=test', 'user', 'pass');
@@ -43,14 +43,14 @@ class DatabaseConnectorTest extends TestCase
 
     public function testMissingHostThrows(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConnectionException::class);
         $this->expectExceptionMessage('Missing host from DSN string');
         new DatabaseConnector('mysql:dbname=test', 'user', 'pass');
     }
 
     public function testMissingDbnameThrows(): void    
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConnectionException::class);
         $this->expectExceptionMessage('Missing database name from DSN string');
         new DatabaseConnector('mysql:host=localhost', 'user', 'pass');
     }

--- a/tests/DumpSettingsTest.php
+++ b/tests/DumpSettingsTest.php
@@ -5,7 +5,7 @@ namespace Druidfi\Mysqldump\Tests;
 use Druidfi\Mysqldump\DumpSettings;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 
 #[CoversClass(DumpSettings::class)]
 class DumpSettingsTest extends TestCase
@@ -76,7 +76,7 @@ class DumpSettingsTest extends TestCase
      */
     public function testInvalidSettings(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Unexpected value in dumpSettings');
         
         new DumpSettings(['invalid-setting' => true]);
@@ -87,7 +87,7 @@ class DumpSettingsTest extends TestCase
      */
     public function testInvalidTableSettings(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Include-tables and exclude-tables should be arrays');
         
         new DumpSettings(['include-tables' => 'users']);
@@ -232,7 +232,7 @@ class DumpSettingsTest extends TestCase
      */
     public function testReplaceAndInsertIgnoreMutualExclusion(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Cannot use both replace and insert-ignore options simultaneously');
 
         new DumpSettings([
@@ -246,7 +246,7 @@ class DumpSettingsTest extends TestCase
      */
     public function testCompressLevelAboveMethodMaximumIsRejected(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Compression level 10 is out of range for Gzip (1-9)');
 
         new DumpSettings([

--- a/tests/ExceptionHierarchyTest.php
+++ b/tests/ExceptionHierarchyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump\Tests;
+
+use Druidfi\Mysqldump\Exception\ConfigurationException;
+use Druidfi\Mysqldump\Exception\ConnectionException;
+use Druidfi\Mysqldump\Exception\DumpException;
+use Druidfi\Mysqldump\Exception\MysqldumpException;
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the exception hierarchy: every library exception must extend
+ * MysqldumpException, which itself extends the native Exception so
+ * pre-3.x catch (Exception) blocks keep working.
+ */
+#[CoversClass(MysqldumpException::class)]
+#[CoversClass(ConnectionException::class)]
+#[CoversClass(ConfigurationException::class)]
+#[CoversClass(DumpException::class)]
+class ExceptionHierarchyTest extends TestCase
+{
+    /**
+     * @return array<string, array{class-string}>
+     */
+    public static function exceptionClassProvider(): array
+    {
+        return [
+            'connection' => [ConnectionException::class],
+            'configuration' => [ConfigurationException::class],
+            'dump' => [DumpException::class],
+        ];
+    }
+
+    #[DataProvider('exceptionClassProvider')]
+    public function testExtendsMysqldumpException(string $class): void
+    {
+        $exception = new $class('test');
+
+        $this->assertInstanceOf(MysqldumpException::class, $exception);
+    }
+
+    public function testBaseExceptionKeepsNativeCatchBlocksWorking(): void
+    {
+        $this->assertInstanceOf(Exception::class, new MysqldumpException('test'));
+    }
+}

--- a/tests/MysqldumpAdapterTest.php
+++ b/tests/MysqldumpAdapterTest.php
@@ -7,7 +7,7 @@ use Druidfi\Mysqldump\Tests\Doubles\FakeTypeAdapter;
 use Druidfi\Mysqldump\TypeAdapter\TypeAdapterMysql;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 use PDO;
 use ReflectionProperty;
 
@@ -17,7 +17,7 @@ class MysqldumpAdapterTest extends TestCase
     public function testAddTypeAdapterRejectsInvalidClass(): void
     {
         $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'user', 'pass');
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessageMatches('/Adapter .* is not instance of/');
         $dump->addTypeAdapter(\stdClass::class);
     }

--- a/tests/MysqldumpTest.php
+++ b/tests/MysqldumpTest.php
@@ -2,6 +2,7 @@
 
 namespace Druidfi\Mysqldump\Tests;
 
+use Druidfi\Mysqldump\Exception\ConnectionException;
 use Druidfi\Mysqldump\Mysqldump;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -54,25 +55,25 @@ class MysqldumpTest extends TestCase
 
     public function testDSNStringExits(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ConnectionException::class);
         $dump = new Mysqldump('', 'testing', 'testing');
     }
 
     public function testHostExits(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ConnectionException::class);
         $dump = new Mysqldump('mysql: dbname=test;', 'testing', 'testing');
     }
 
     public function testDBTypeExists(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ConnectionException::class);
         $dump = new Mysqldump('host=localhost; dbname=test;', 'testing', 'testing');
     }
 
     public function testDBNameExists(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ConnectionException::class);
         $dump = new Mysqldump('mysql: host=localhost', 'testing', 'testing');
     }
 

--- a/tests/ReplaceTest.php
+++ b/tests/ReplaceTest.php
@@ -6,7 +6,7 @@ use Druidfi\Mysqldump\DumpSettings;
 use Druidfi\Mysqldump\Mysqldump;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Exception;
+use Druidfi\Mysqldump\Exception\ConfigurationException;
 
 #[CoversClass(Mysqldump::class)]
 #[CoversClass(DumpSettings::class)]
@@ -51,7 +51,7 @@ class ReplaceTest extends TestCase
      */
     public function testMutualExclusivity(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Cannot use both replace and insert-ignore options simultaneously');
         
         new DumpSettings([


### PR DESCRIPTION
## Summary

Implements task 3 (and with it task 12) from `docs/tasks.md`: a custom exception hierarchy replacing the bare `Exception` used everywhere.

New `Druidfi\Mysqldump\Exception` namespace:

| Class | Thrown for |
|---|---|
| `MysqldumpException` | Base class for all library errors (extends native `Exception`) |
| `ConnectionException` | Malformed DSN strings, PDO connection failures |
| `ConfigurationException` | Unknown/invalid/conflicting settings, include-tables that don't exist, unknown compression methods, compression extensions not installed |
| `DumpException` | Output not writable, write failures (disk full), unexpected server output while reading object structures |

## Backward compatibility

`MysqldumpException` extends the native `Exception`, so existing `catch (\Exception $e)` blocks keep working. No messages changed. Notable classification choice: a compression method whose extension is missing throws `ConfigurationException` (the config asks for something unavailable), while runtime I/O failures in the same compressor classes throw `DumpException`.

## Also included

- All `@throws` docblocks updated to name the specific exception type (task 12)
- Tests tightened from `Exception::class` to the specific classes; new `ExceptionHierarchyTest` guards the hierarchy and the native-`Exception` BC guarantee
- README: new "Error handling" section, upgrade note under "Upgrading from 2.x to 3.x", getting-started example now catches `MysqldumpException`
- `CLAUDE.md` error-handling notes and structure tree updated; tasks 3 and 12 checked off in `docs/tasks.md`

## Test plan

- [x] `vendor/bin/phpunit` — 68 tests, 154 assertions, all passing
- [x] `vendor/bin/phpstan` — level 6, no errors
- [x] `vendor/bin/rector process --dry-run` — clean
- [x] CI integration tests against MySQL 8.0/8.4 and MariaDB 10.11 (output is unaffected; only exception types changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)