### PR TITLE
refactor: extract table data dumping into TableDataDumper class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,10 @@ Bug fixes relevant to both lines land on `main` first and are backported to `2.x
 
 ```
 src/
-├── Mysqldump.php              # Main orchestrator class (~1100 lines)
+├── Mysqldump.php              # Main orchestrator class (~750 lines)
 ├── DumpSettings.php           # Configuration management
 ├── DumpWriter.php             # File output handler
+├── TableDataDumper.php        # Table row data dumper (INSERT/REPLACE statements)
 ├── DatabaseConnector.php      # PDO connection management
 ├── ConfigValidator.php        # Settings validation via reflection
 ├── ConfigOption.php           # Config constants with PHP 8 attributes
@@ -274,7 +275,7 @@ $dump->getAdapter(PDO $conn);
 1. **Optional Extensions**: `ext-zstd` and `ext-lz4` are optional; code must handle their absence gracefully
 2. **PHP 8.5 Deprecation**: `MYSQL_ATTR_USE_BUFFERED_QUERY` is deprecated in PHP 8.5; handled in `DatabaseConnector`
 3. **Integration Tests**: Output must match native mysqldump exactly (whitespace-sensitive)
-4. **Large Mysqldump Class**: The main class is ~1100 lines; consider impact when modifying
+4. **Large Mysqldump Class**: The main class is ~750 lines; consider impact when modifying
 5. **Closure Callbacks**: ObjectDumpers receive closures, not direct dependencies
 
 ## Links

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -6,12 +6,14 @@ codebase; items that are done are kept checked for history.
 
 ## Architecture Improvements
 
-1. [ ] Refactor the large Mysqldump class (~1090 lines) into smaller, more focused classes:
+1. [x] Refactor the large Mysqldump class (~1090 lines, now ~750) into smaller, more focused classes:
    - [x] Create a separate DatabaseConnector class to handle connection logic
    - [x] Create a separate DumpWriter class to handle file output
    - [x] Create separate classes for different database object types (Tables, Views, Triggers, etc.)
-   - [ ] Extract table data dumping (`listValues()`, `prepareListValues()`, `endListValues()`,
-         `prepareColumnValues()`, `getColumnStmt()`, `getColumnNames()`) into a dedicated class
+   - [x] Extract table data dumping (`listValues()`, `prepareListValues()`, `endListValues()`,
+         `prepareColumnValues()`, `getColumnStmt()`, `getColumnNames()`) into a dedicated
+         `TableDataDumper` class (state still living on Mysqldump — column types, wheres/limits,
+         hooks — is passed in as closures; unit-tested against SQLite in `TableDataDumperTest`)
    - [x] Remove the vestigial `getDatabaseStructure*()` methods: five were empty no-ops and
          `getDatabaseStructureTables()` only validated include-tables (now `validateIncludedTables()`)
    - [x] Deduplicate the six near-identical `iterate*()` generators into one shared
@@ -78,7 +80,8 @@ codebase; items that are done are kept checked for history.
    - [ ] Extract the repeated comment-header writing (`skipComments()` + sprintf block) into a helper
 
 9. [ ] Improve method organization:
-   - [ ] Break up `listValues()` (~95 lines) into smaller private methods
+   - [ ] Break up `TableDataDumper::dump()` (~95 lines, formerly `Mysqldump::listValues()`)
+         into smaller private methods
    - [ ] Group related methods together in `Mysqldump.php`
 
 10. [x] Enhance type safety (baseline):

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -99,19 +99,6 @@ class Mysqldump
         return $this->writer->write($data);
     }
 
-    private function getInsertType(): InsertType
-    {
-        if ($this->settings->isEnabled('replace')) {
-            return InsertType::Replace;
-        }
-
-        if ($this->settings->isEnabled('insert-ignore')) {
-            return InsertType::InsertIgnore;
-        }
-
-        return InsertType::Insert;
-    }
-
     /**
      * Primary function, triggers dumping.
      *
@@ -161,15 +148,29 @@ class Mysqldump
             $this->write($this->db->databases($this->connector->getDbName()));
         }
 
+        // Dumps the data rows of each table
+        $dataDumper = new TableDataDumper(
+            conn: $this->conn,
+            settings: $this->settings,
+            db: $this->db,
+            writer: $this->writer,
+            getColumnTypes: fn(string $table): array => $this->tableColumnTypes[$table],
+            getTableWhere: $this->getTableWhere(...),
+            getTableLimit: $this->getTableLimit(...),
+            transformTableRow: $this->transformTableRowCallable,
+            transformColumnValue: $this->transformColumnValueCallable,
+            info: $this->infoCallable
+        );
+
         // Use dedicated dumpers for different object types
         $tablesDumper = new ObjectDumper\TablesDumper(
             iterateTables: fn(): \Generator => $this->iterateTables(),
             matches: fn(string $name, array $arr): bool => $this->matches($name, $arr),
             getTableStructure: function (string $table): void { $this->getTableStructure($table); },
-            listValues: function (string $table): void {
+            listValues: function (string $table) use ($dataDumper): void {
                 $no_data = $this->settings->isEnabled('no-data');
                 if (!$no_data && !$this->matches($table, $this->settings->getNoData())) {
-                    $this->listValues($table);
+                    $dataDumper->dump($table);
                 }
             },
             getExcludedTables: fn(): array => $this->settings->getExcludedTables(),
@@ -637,274 +638,6 @@ class Mysqldump
             return;
         }
         $stmtSCE->closeCursor();
-    }
-
-    /**
-     * Prepare values for output.
-     *
-     * @param string $tableName Name of table which contains rows
-     * @param array<string, mixed> $row Associative array of column names and values to be quoted
-     * @return array<int, mixed> quoted values ready for the VALUES list
-     */
-    private function prepareColumnValues(string $tableName, array $row): array
-    {
-        $ret = [];
-        $columnTypes = $this->tableColumnTypes[$tableName];
-
-        if ($this->transformTableRowCallable) {
-            $row = ($this->transformTableRowCallable)($tableName, $row);
-        }
-
-        $dbHandler = $this->conn;
-        $hexBlobEnabled = $this->settings->isEnabled('hex-blob');
-        foreach ($row as $colName => $colValue) {
-            if ($this->transformColumnValueCallable) {
-                $colValue = ($this->transformColumnValueCallable)($tableName, $colName, $colValue, $row);
-            }
-
-            if ($colValue === null) {
-                $ret[] = "NULL";
-                continue;
-            }
-
-            $colType = $columnTypes[$colName];
-            if ($hexBlobEnabled && $colType['is_blob']) {
-                if ($colType['type'] == 'bit' || $colValue !== '') {
-                    $ret[] = sprintf('0x%s', $colValue);
-                } else {
-                    $ret[] = "''";
-                }
-                continue;
-            }
-
-            if ($colType['is_numeric']) {
-                $ret[] = $colValue;
-                continue;
-            }
-
-            $ret[] = $dbHandler->quote($colValue);
-        }
-
-        return $ret;
-    }
-
-    /**
-     * Table rows extractor.
-     *
-     * @param string $tableName Name of table to export
-     */
-    private function listValues(string $tableName): void
-    {
-        $this->prepareListValues($tableName);
-
-        $onlyOnce = true;
-        $lineSize = 0;
-        $colNames = [];
-
-        // getting the column statement has side effect, so we backup this setting for consitency
-        $completeInsertBackup = $this->settings->isEnabled('complete-insert');
-
-        // colStmt is used to form a query to obtain row values
-        $colStmt = $this->getColumnStmt($tableName);
-
-        // colNames is used to get the name of the columns when using complete-insert
-        if ($this->settings->isEnabled('complete-insert')) {
-            $colNames = $this->getColumnNames($tableName);
-        }
-
-        $stmt = "SELECT " . implode(",", $colStmt) . " FROM `$tableName`";
-
-        // Table specific conditions override the default 'where'
-        $condition = $this->getTableWhere($tableName);
-
-        if ($condition) {
-            $stmt .= sprintf(' WHERE %s', $condition);
-        }
-
-        if ($limit = $this->getTableLimit($tableName)) {
-            $stmt .= is_numeric($limit) ?
-                sprintf(' LIMIT %d', $limit) :
-                sprintf(' LIMIT %s', $limit);
-        }
-
-        $resultSet = $this->conn->query($stmt);
-        $resultSet->setFetchMode(PDO::FETCH_ASSOC);
-
-        $insertType = $this->getInsertType()->value;
-        $count = 0;
-
-        $isInfoCallable = $this->infoCallable !== null;
-        if ($isInfoCallable) {
-            ($this->infoCallable)('table', ['name' => $tableName, 'completed' => false, 'rowCount' => $count]);
-        }
-
-        $line = '';
-        foreach ($resultSet as $row) {
-            $count++;
-            $values = $this->prepareColumnValues($tableName, $row);
-            $valueList = implode(',', $values);
-
-            if ($onlyOnce || !$this->settings->isEnabled('extended-insert')) {
-                if ($this->settings->isEnabled('complete-insert') && count($colNames)) {
-                    $line .= sprintf(
-                        '%s INTO `%s` (%s) VALUES (%s)',
-                        $insertType,
-                        $tableName,
-                        implode(', ', $colNames),
-                        $valueList
-                    );
-                } else {
-                    $line .= sprintf('%s INTO `%s` VALUES (%s)', $insertType, $tableName, $valueList);
-                }
-                $onlyOnce = false;
-            } else {
-                $line .= sprintf(',(%s)', $valueList);
-            }
-
-            if ((strlen($line) > $this->settings->getNetBufferLength())
-                || !$this->settings->isEnabled('extended-insert')) {
-                $onlyOnce = true;
-                $this->write($line . ';' . PHP_EOL);
-                $line = '';
-
-                if ($isInfoCallable) {
-                    ($this->infoCallable)('table', ['name' => $tableName, 'completed' => false, 'rowCount' => $count]);
-                }
-            }
-        }
-
-        $resultSet->closeCursor();
-
-        if ($line !== '') {
-            $this->write($line. ';' . PHP_EOL);
-        }
-
-        $this->endListValues($tableName, $count);
-
-        if ($isInfoCallable) {
-            ($this->infoCallable)('table', ['name' => $tableName, 'completed' => true, 'rowCount' => $count]);
-        }
-
-        $this->settings->setCompleteInsert($completeInsertBackup);
-    }
-
-    /**
-     * Table rows extractor, append information prior to dump.
-     *
-     * @param string $tableName Name of table to export
-     */
-    private function prepareListValues(string $tableName): void
-    {
-        if (!$this->settings->skipComments()) {
-            $this->write(
-                "--" . PHP_EOL .
-                "-- Dumping data for table `$tableName`" . PHP_EOL .
-                "--" . PHP_EOL . PHP_EOL
-            );
-        }
-
-        if ($this->settings->isEnabled('lock-tables') && !$this->settings->isEnabled('single-transaction')) {
-            $this->db->lockTable($tableName);
-        }
-
-        if ($this->settings->isEnabled('add-locks')) {
-            $this->write($this->db->startAddLockTable($tableName));
-        }
-
-        if ($this->settings->isEnabled('disable-keys')) {
-            $this->write($this->db->startAddDisableKeys($tableName));
-        }
-
-        // Disable autocommit for faster reload
-        if ($this->settings->isEnabled('no-autocommit')) {
-            $this->write($this->db->startDisableAutocommit());
-        }
-    }
-
-    /**
-     * Table rows extractor, close locks and commits after dump.
-     *
-     * @param string $tableName Name of table to export.
-     * @param integer $count Number of rows inserted.
-     */
-    private function endListValues(string $tableName, int $count = 0): void
-    {
-        if ($this->settings->isEnabled('disable-keys')) {
-            $this->write($this->db->endAddDisableKeys($tableName));
-        }
-
-        if ($this->settings->isEnabled('add-locks')) {
-            $this->write($this->db->endAddLockTable($tableName));
-        }
-
-        if ($this->settings->isEnabled('lock-tables')
-            && !$this->settings->isEnabled('single-transaction')) {
-            $this->db->unlockTable($tableName);
-        }
-
-        // Commit to enable autocommit
-        if ($this->settings->isEnabled('no-autocommit')) {
-            $this->write($this->db->endDisableAutocommit());
-        }
-
-        $this->write(PHP_EOL);
-
-        if (!$this->settings->skipComments()) {
-            $this->write(
-                "-- Dumped table `" . $tableName . "` with $count row(s)" . PHP_EOL .
-                '--' . PHP_EOL . PHP_EOL
-            );
-        }
-    }
-
-    /**
-     * Build SQL List of all columns on current table which will be used for selecting.
-     *
-     * @param string $tableName Name of table to get columns
-     *
-     * @return string[] SQL sentence with columns for select
-     */
-    protected function getColumnStmt(string $tableName): array
-    {
-        $colStmt = [];
-        foreach ($this->tableColumnTypes[$tableName] as $colName => $colType) {
-            if ($colType['is_virtual']) {
-                $this->settings->setCompleteInsert();
-            } elseif ($colType['type'] == 'double') {
-                // PHP 8.1+ returns double fields with float precision issues; dump via CONCAT
-                $colStmt[] = sprintf("CONCAT(`%s`) AS `%s`", $colName, $colName);
-            } elseif ($colType['type'] === 'bit' && $this->settings->isEnabled('hex-blob')) {
-                $colStmt[] = sprintf("LPAD(HEX(`%s`),2,'0') AS `%s`", $colName, $colName);
-            } elseif ($colType['is_blob'] && $this->settings->isEnabled('hex-blob')) {
-                $colStmt[] = sprintf("HEX(`%s`) AS `%s`", $colName, $colName);
-            } else {
-                $colStmt[] = sprintf("`%s`", $colName);
-            }
-        }
-
-        return $colStmt;
-    }
-
-    /**
-     * Build SQL List of all columns on current table which will be used for inserting.
-     *
-     * @param string $tableName Name of table to get columns
-     *
-     * @return string[] columns for sql sentence for insert
-     */
-    private function getColumnNames(string $tableName): array
-    {
-        $colNames = [];
-
-        foreach ($this->tableColumnTypes[$tableName] as $colName => $colType) {
-            if ($colType['is_virtual']) {
-                $this->settings->setCompleteInsert();
-            } else {
-                $colNames[] = sprintf('`%s`', $colName);
-            }
-        }
-
-        return $colNames;
     }
 
     /**

--- a/src/TableDataDumper.php
+++ b/src/TableDataDumper.php
@@ -1,0 +1,323 @@
+<?php
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump;
+
+use Closure;
+use Druidfi\Mysqldump\Exception\DumpException;
+use Druidfi\Mysqldump\TypeAdapter\TypeAdapterInterface;
+use PDO;
+
+/**
+ * Dumps the data rows of a single table as INSERT/REPLACE statements.
+ *
+ * Owns the SELECT statement building, value quoting and the surrounding
+ * lock/disable-keys/autocommit statements for one table's data section.
+ * Column type information is collected by Mysqldump while dumping table
+ * structures and looked up through the getColumnTypes closure.
+ */
+class TableDataDumper
+{
+    /**
+     * @param Closure $getColumnTypes function(string $table): array<string, array<string, mixed>>
+     * @param Closure $getTableWhere function(string $table): string|false
+     * @param Closure $getTableLimit function(string $table): int|string|false
+     * @param Closure|null $transformTableRow function(string $table, array $row): array
+     * @param Closure|null $transformColumnValue function(string $table, string $col, mixed $value, array $row): mixed
+     * @param Closure|null $info function(string $object, array $payload): void
+     */
+    public function __construct(
+        private readonly PDO $conn,
+        private readonly DumpSettings $settings,
+        private readonly TypeAdapterInterface $db,
+        private readonly DumpWriter $writer,
+        private readonly Closure $getColumnTypes,
+        private readonly Closure $getTableWhere,
+        private readonly Closure $getTableLimit,
+        private readonly ?Closure $transformTableRow = null,
+        private readonly ?Closure $transformColumnValue = null,
+        private readonly ?Closure $info = null,
+    ) {
+    }
+
+    /**
+     * Table rows extractor.
+     *
+     * @param string $tableName Name of table to export
+     * @throws DumpException
+     */
+    public function dump(string $tableName): void
+    {
+        $this->prepareListValues($tableName);
+
+        $onlyOnce = true;
+        $colNames = [];
+        $columnTypes = ($this->getColumnTypes)($tableName);
+
+        // getting the column statement has side effect, so we backup this setting for consitency
+        $completeInsertBackup = $this->settings->isEnabled('complete-insert');
+
+        // colStmt is used to form a query to obtain row values
+        $colStmt = $this->getColumnStmt($columnTypes);
+
+        // colNames is used to get the name of the columns when using complete-insert
+        if ($this->settings->isEnabled('complete-insert')) {
+            $colNames = $this->getColumnNames($columnTypes);
+        }
+
+        $stmt = "SELECT " . implode(",", $colStmt) . " FROM `$tableName`";
+
+        // Table specific conditions override the default 'where'
+        $condition = ($this->getTableWhere)($tableName);
+
+        if ($condition) {
+            $stmt .= sprintf(' WHERE %s', $condition);
+        }
+
+        if ($limit = ($this->getTableLimit)($tableName)) {
+            $stmt .= is_numeric($limit) ?
+                sprintf(' LIMIT %d', $limit) :
+                sprintf(' LIMIT %s', $limit);
+        }
+
+        $resultSet = $this->conn->query($stmt);
+        $resultSet->setFetchMode(PDO::FETCH_ASSOC);
+
+        $insertType = $this->getInsertType()->value;
+        $count = 0;
+
+        $isInfoCallable = $this->info !== null;
+        if ($isInfoCallable) {
+            ($this->info)('table', ['name' => $tableName, 'completed' => false, 'rowCount' => $count]);
+        }
+
+        $line = '';
+        foreach ($resultSet as $row) {
+            $count++;
+            $values = $this->prepareColumnValues($tableName, $columnTypes, $row);
+            $valueList = implode(',', $values);
+
+            if ($onlyOnce || !$this->settings->isEnabled('extended-insert')) {
+                if ($this->settings->isEnabled('complete-insert') && count($colNames)) {
+                    $line .= sprintf(
+                        '%s INTO `%s` (%s) VALUES (%s)',
+                        $insertType,
+                        $tableName,
+                        implode(', ', $colNames),
+                        $valueList
+                    );
+                } else {
+                    $line .= sprintf('%s INTO `%s` VALUES (%s)', $insertType, $tableName, $valueList);
+                }
+                $onlyOnce = false;
+            } else {
+                $line .= sprintf(',(%s)', $valueList);
+            }
+
+            if ((strlen($line) > $this->settings->getNetBufferLength())
+                || !$this->settings->isEnabled('extended-insert')) {
+                $onlyOnce = true;
+                $this->writer->write($line . ';' . PHP_EOL);
+                $line = '';
+
+                if ($isInfoCallable) {
+                    ($this->info)('table', ['name' => $tableName, 'completed' => false, 'rowCount' => $count]);
+                }
+            }
+        }
+
+        $resultSet->closeCursor();
+
+        if ($line !== '') {
+            $this->writer->write($line. ';' . PHP_EOL);
+        }
+
+        $this->endListValues($tableName, $count);
+
+        if ($isInfoCallable) {
+            ($this->info)('table', ['name' => $tableName, 'completed' => true, 'rowCount' => $count]);
+        }
+
+        $this->settings->setCompleteInsert($completeInsertBackup);
+    }
+
+    private function getInsertType(): InsertType
+    {
+        if ($this->settings->isEnabled('replace')) {
+            return InsertType::Replace;
+        }
+
+        if ($this->settings->isEnabled('insert-ignore')) {
+            return InsertType::InsertIgnore;
+        }
+
+        return InsertType::Insert;
+    }
+
+    /**
+     * Table rows extractor, append information prior to dump.
+     *
+     * @param string $tableName Name of table to export
+     * @throws DumpException
+     */
+    private function prepareListValues(string $tableName): void
+    {
+        if (!$this->settings->skipComments()) {
+            $this->writer->write(
+                "--" . PHP_EOL .
+                "-- Dumping data for table `$tableName`" . PHP_EOL .
+                "--" . PHP_EOL . PHP_EOL
+            );
+        }
+
+        if ($this->settings->isEnabled('lock-tables') && !$this->settings->isEnabled('single-transaction')) {
+            $this->db->lockTable($tableName);
+        }
+
+        if ($this->settings->isEnabled('add-locks')) {
+            $this->writer->write($this->db->startAddLockTable($tableName));
+        }
+
+        if ($this->settings->isEnabled('disable-keys')) {
+            $this->writer->write($this->db->startAddDisableKeys($tableName));
+        }
+
+        // Disable autocommit for faster reload
+        if ($this->settings->isEnabled('no-autocommit')) {
+            $this->writer->write($this->db->startDisableAutocommit());
+        }
+    }
+
+    /**
+     * Table rows extractor, close locks and commits after dump.
+     *
+     * @param string $tableName Name of table to export.
+     * @param integer $count Number of rows inserted.
+     * @throws DumpException
+     */
+    private function endListValues(string $tableName, int $count = 0): void
+    {
+        if ($this->settings->isEnabled('disable-keys')) {
+            $this->writer->write($this->db->endAddDisableKeys($tableName));
+        }
+
+        if ($this->settings->isEnabled('add-locks')) {
+            $this->writer->write($this->db->endAddLockTable($tableName));
+        }
+
+        if ($this->settings->isEnabled('lock-tables')
+            && !$this->settings->isEnabled('single-transaction')) {
+            $this->db->unlockTable($tableName);
+        }
+
+        // Commit to enable autocommit
+        if ($this->settings->isEnabled('no-autocommit')) {
+            $this->writer->write($this->db->endDisableAutocommit());
+        }
+
+        $this->writer->write(PHP_EOL);
+
+        if (!$this->settings->skipComments()) {
+            $this->writer->write(
+                "-- Dumped table `" . $tableName . "` with $count row(s)" . PHP_EOL .
+                '--' . PHP_EOL . PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Prepare values for output.
+     *
+     * @param string $tableName Name of table which contains rows
+     * @param array<string, array<string, mixed>> $columnTypes Column type info for the table
+     * @param array<string, mixed> $row Associative array of column names and values to be quoted
+     * @return array<int, mixed> quoted values ready for the VALUES list
+     */
+    private function prepareColumnValues(string $tableName, array $columnTypes, array $row): array
+    {
+        $ret = [];
+
+        if ($this->transformTableRow) {
+            $row = ($this->transformTableRow)($tableName, $row);
+        }
+
+        $hexBlobEnabled = $this->settings->isEnabled('hex-blob');
+        foreach ($row as $colName => $colValue) {
+            if ($this->transformColumnValue) {
+                $colValue = ($this->transformColumnValue)($tableName, $colName, $colValue, $row);
+            }
+
+            if ($colValue === null) {
+                $ret[] = "NULL";
+                continue;
+            }
+
+            $colType = $columnTypes[$colName];
+            if ($hexBlobEnabled && $colType['is_blob']) {
+                if ($colType['type'] == 'bit' || $colValue !== '') {
+                    $ret[] = sprintf('0x%s', $colValue);
+                } else {
+                    $ret[] = "''";
+                }
+                continue;
+            }
+
+            if ($colType['is_numeric']) {
+                $ret[] = $colValue;
+                continue;
+            }
+
+            $ret[] = $this->conn->quote($colValue);
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Build SQL List of all columns on current table which will be used for selecting.
+     *
+     * @param array<string, array<string, mixed>> $columnTypes Column type info for the table
+     * @return string[] SQL sentence with columns for select
+     */
+    private function getColumnStmt(array $columnTypes): array
+    {
+        $colStmt = [];
+        foreach ($columnTypes as $colName => $colType) {
+            if ($colType['is_virtual']) {
+                $this->settings->setCompleteInsert();
+            } elseif ($colType['type'] == 'double') {
+                // PHP 8.1+ returns double fields with float precision issues; dump via CONCAT
+                $colStmt[] = sprintf("CONCAT(`%s`) AS `%s`", $colName, $colName);
+            } elseif ($colType['type'] === 'bit' && $this->settings->isEnabled('hex-blob')) {
+                $colStmt[] = sprintf("LPAD(HEX(`%s`),2,'0') AS `%s`", $colName, $colName);
+            } elseif ($colType['is_blob'] && $this->settings->isEnabled('hex-blob')) {
+                $colStmt[] = sprintf("HEX(`%s`) AS `%s`", $colName, $colName);
+            } else {
+                $colStmt[] = sprintf("`%s`", $colName);
+            }
+        }
+
+        return $colStmt;
+    }
+
+    /**
+     * Build SQL List of all columns on current table which will be used for inserting.
+     *
+     * @param array<string, array<string, mixed>> $columnTypes Column type info for the table
+     * @return string[] columns for sql sentence for insert
+     */
+    private function getColumnNames(array $columnTypes): array
+    {
+        $colNames = [];
+
+        foreach ($columnTypes as $colName => $colType) {
+            if ($colType['is_virtual']) {
+                $this->settings->setCompleteInsert();
+            } else {
+                $colNames[] = sprintf('`%s`', $colName);
+            }
+        }
+
+        return $colNames;
+    }
+}

--- a/tests/TableDataDumperTest.php
+++ b/tests/TableDataDumperTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Druidfi\Mysqldump\Tests;
+
+use Druidfi\Mysqldump\DumpSettings;
+use Druidfi\Mysqldump\DumpWriter;
+use Druidfi\Mysqldump\TableDataDumper;
+use Druidfi\Mysqldump\Tests\Doubles\FakeTypeAdapter;
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TableDataDumper::class)]
+class TableDataDumperTest extends TestCase
+{
+    private PDO $pdo;
+    private string $outputFile;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->exec('CREATE TABLE users (id INTEGER, name TEXT)');
+        $this->pdo->exec("INSERT INTO users VALUES (1, 'John'), (2, 'O''Hara')");
+        $this->outputFile = tempnam(sys_get_temp_dir(), 'mysqldump-php-test');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->outputFile)) {
+            unlink($this->outputFile);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $overrides
+     */
+    private function dumpUsersTable(array $settings = [], array $overrides = []): string
+    {
+        $dumpSettings = new DumpSettings($settings + ['skip-comments' => true]);
+        $writer = new DumpWriter($dumpSettings);
+        $writer->initialize($this->outputFile);
+
+        $columnTypes = [
+            'id' => ['is_numeric' => true, 'is_blob' => false, 'type' => 'int', 'type_sql' => 'int', 'is_virtual' => false],
+            'name' => ['is_numeric' => false, 'is_blob' => false, 'type' => 'text', 'type_sql' => 'text', 'is_virtual' => false],
+        ];
+
+        $dumper = new TableDataDumper(
+            conn: $this->pdo,
+            settings: $dumpSettings,
+            db: new FakeTypeAdapter($this->pdo, $dumpSettings),
+            writer: $writer,
+            getColumnTypes: fn(string $table): array => $columnTypes,
+            getTableWhere: $overrides['getTableWhere'] ?? fn(string $table): false => false,
+            getTableLimit: $overrides['getTableLimit'] ?? fn(string $table): false => false,
+            transformTableRow: $overrides['transformTableRow'] ?? null,
+            transformColumnValue: $overrides['transformColumnValue'] ?? null,
+            info: $overrides['info'] ?? null,
+        );
+
+        $dumper->dump('users');
+        $writer->close();
+
+        return file_get_contents($this->outputFile);
+    }
+
+    public function testDumpsRowsAsExtendedInsert(): void
+    {
+        $output = $this->dumpUsersTable();
+
+        $this->assertStringContainsString("INSERT INTO `users` VALUES (1,'John'),(2,'O''Hara');", $output);
+    }
+
+    public function testReplaceSettingProducesReplaceStatements(): void
+    {
+        $output = $this->dumpUsersTable(['replace' => true]);
+
+        $this->assertStringContainsString('REPLACE INTO `users` VALUES', $output);
+        $this->assertStringNotContainsString('INSERT INTO', $output);
+    }
+
+    public function testInsertIgnoreSettingProducesInsertIgnoreStatements(): void
+    {
+        $output = $this->dumpUsersTable(['insert-ignore' => true]);
+
+        // Native mysqldump writes a double space in INSERT  IGNORE.
+        $this->assertStringContainsString('INSERT  IGNORE INTO `users` VALUES', $output);
+    }
+
+    public function testCompleteInsertIncludesColumnNames(): void
+    {
+        $output = $this->dumpUsersTable(['complete-insert' => true]);
+
+        $this->assertStringContainsString('INSERT INTO `users` (`id`, `name`) VALUES', $output);
+    }
+
+    public function testExtendedInsertDisabledWritesOneStatementPerRow(): void
+    {
+        $output = $this->dumpUsersTable(['extended-insert' => false]);
+
+        $this->assertStringContainsString("INSERT INTO `users` VALUES (1,'John');", $output);
+        $this->assertStringContainsString("INSERT INTO `users` VALUES (2,'O''Hara');", $output);
+    }
+
+    public function testTableWhereFiltersRows(): void
+    {
+        $output = $this->dumpUsersTable(overrides: [
+            'getTableWhere' => fn(string $table): string => 'id = 1',
+        ]);
+
+        $this->assertStringContainsString("(1,'John')", $output);
+        $this->assertStringNotContainsString("O''Hara", $output);
+    }
+
+    public function testTableLimitLimitsRows(): void
+    {
+        $output = $this->dumpUsersTable(overrides: [
+            'getTableLimit' => fn(string $table): int => 1,
+        ]);
+
+        $this->assertStringContainsString("(1,'John')", $output);
+        $this->assertStringNotContainsString("O''Hara", $output);
+    }
+
+    public function testTransformColumnValueHookIsApplied(): void
+    {
+        $output = $this->dumpUsersTable(overrides: [
+            'transformColumnValue' => fn(string $table, string $col, mixed $value, array $row): mixed =>
+                $col === 'name' ? 'anonymous' : $value,
+        ]);
+
+        $this->assertStringContainsString("(1,'anonymous'),(2,'anonymous')", $output);
+        $this->assertStringNotContainsString('John', $output);
+    }
+
+    public function testTransformTableRowHookIsApplied(): void
+    {
+        $output = $this->dumpUsersTable(overrides: [
+            'transformTableRow' => fn(string $table, array $row): array =>
+                ['id' => $row['id'], 'name' => strtoupper((string) $row['name'])],
+        ]);
+
+        $this->assertStringContainsString("(1,'JOHN')", $output);
+    }
+
+    public function testNullValuesAreDumpedAsNull(): void
+    {
+        $this->pdo->exec('INSERT INTO users VALUES (3, NULL)');
+
+        $output = $this->dumpUsersTable();
+
+        $this->assertStringContainsString('(3,NULL)', $output);
+    }
+
+    public function testInfoHookReportsRowCount(): void
+    {
+        $payloads = [];
+        $this->dumpUsersTable(overrides: [
+            'info' => function (string $object, array $payload) use (&$payloads): void {
+                $payloads[] = [$object, $payload];
+            },
+        ]);
+
+        $this->assertSame(['table', ['name' => 'users', 'completed' => false, 'rowCount' => 0]], $payloads[0]);
+        $this->assertSame(['table', ['name' => 'users', 'completed' => true, 'rowCount' => 2]], end($payloads));
+    }
+}


### PR DESCRIPTION
## What

Extracts the table data dumping logic out of the `Mysqldump` class into a dedicated `TableDataDumper` class, completing the last open item of task 1 in `docs/tasks.md`.

- `listValues()` (now `dump()`), `prepareListValues()`, `endListValues()`, `prepareColumnValues()`, `getColumnStmt()` and `getColumnNames()` move to `src/TableDataDumper.php`, along with `getInsertType()` which only reads settings. `Mysqldump` shrinks from ~1040 to 749 lines.
- Real dependencies (PDO, `DumpSettings`, `TypeAdapterInterface`, `DumpWriter`) are constructor-injected; state still living on `Mysqldump` — the column type map collected during structure dumping, per-table wheres/limits and the transform/info hooks — is passed in as closures, matching the wiring style of the `ObjectDumper` classes.
- Two small cleanups in the move: the dead `$lineSize` local is gone, and column types are fetched once per table instead of on every row.
- New `tests/TableDataDumperTest.php`: 11 unit tests against an in-memory SQLite PDO with the existing `FakeTypeAdapter`, covering extended/non-extended inserts, REPLACE, INSERT IGNORE, complete-insert column lists, where/limit closures, both transform hooks, NULL handling and info-hook row counts.
- `docs/tasks.md` task 1 checked off (task 9's `listValues()` reference repointed), CLAUDE.md structure/size notes refreshed.

## Why

Task 1 of the improvement roadmap: refactor the large `Mysqldump` class into smaller, focused classes. Data dumping was the last responsibility left inline after `DatabaseConnector`, `DumpWriter` and the `ObjectDumper` classes were extracted.

The public API is unchanged. One deliberate API note: `getColumnStmt()` was `protected` and is now private on the new class — a subclass-visible change appropriate for the in-development 3.x major.

## Testing

- `vendor/bin/phpunit` — 79 tests, 171 assertions, green
- `vendor/bin/phpstan` — level 6, no errors
- `vendor/bin/rector process --dry-run` — clean
- Docker integration suite (`tests/scripts/test.sh`, 39 byte-for-byte comparisons against native mysqldump) — passes on both MySQL 8.0 and MariaDB 10.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)