### PR TITLE
feat: add ConnectionInterface for swappable database connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ src/
 ├── DumpSettings.php           # Configuration management
 ├── DumpWriter.php             # File output handler
 ├── TableDataDumper.php        # Table row data dumper (INSERT/REPLACE statements)
-├── DatabaseConnector.php      # PDO connection management
+├── ConnectionInterface.php    # Contract for connection providers (swappable/mockable)
+├── DatabaseConnector.php      # PDO connection management (default ConnectionInterface impl)
 ├── ConfigValidator.php        # Settings validation via reflection
 ├── ConfigOption.php           # Config constants with PHP 8 attributes
 ├── InsertType.php             # Enum for INSERT/INSERT IGNORE/REPLACE
@@ -229,6 +230,9 @@ $dump->setInfoHook(callable $hook);
 // Type adapter extension
 $dump->addTypeAdapter(string $adapterClassName);
 $dump->getAdapter(PDO $conn);
+
+// Connection injection (before start)
+$dump->setConnector(ConnectionInterface $connector);
 ```
 
 ### Error Handling

--- a/README.md
+++ b/README.md
@@ -108,6 +108,33 @@ or a subclass to react to a specific failure:
 - `DumpException` — the dump itself failed: output file not writable, a write error (e.g. disk
   full), or an unexpected result from the server while reading object structures.
 
+## Providing your own database connection
+
+By default the connection is built from the DSN, username and password given to the constructor.
+If you need to reuse an existing PDO instance or apply a custom connection strategy, implement
+`Druidfi\Mysqldump\ConnectionInterface` and inject it before starting the dump:
+
+```php
+use Druidfi\Mysqldump\ConnectionInterface;
+use Druidfi\Mysqldump\Mysqldump;
+
+class ExistingPdoConnection implements ConnectionInterface
+{
+    public function __construct(private readonly PDO $pdo) {}
+
+    public function connect(): PDO { return $this->pdo; }
+    public function getHost(): string { return 'app-db'; }
+    public function getDbName(): string { return 'testdb'; }
+}
+
+$dumper = new Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
+$dumper->setConnector(new ExistingPdoConnection($pdo));
+$dumper->start('storage/work/dump.sql');
+```
+
+`getHost()` and `getDbName()` are used in the dump file header comments and in the
+`SHOW`/`CREATE DATABASE` statements, so return the values of the database being dumped.
+
 ## Changing values when exporting
 
 You can register a callable that will be used to transform values during the export. An example use-case for this is

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -35,9 +35,11 @@ codebase; items that are done are kept checked for history.
    - [x] Implement a proper exception hierarchy and document which methods throw what
          (`@throws` docblocks updated throughout; README "Error handling" section added)
 
-4. [ ] Implement interfaces for major components:
+4. [x] Implement interfaces for major components:
    - [x] Create a DumperInterface for different dumper implementations
-   - [ ] Create a ConnectionInterface so DatabaseConnector can be swapped/mocked
+   - [x] Create a ConnectionInterface so DatabaseConnector can be swapped/mocked —
+         `Mysqldump::setConnector()` injects a custom implementation before `start()`;
+         `ConnectionInterfaceTest` runs a full dump against injected SQLite to prove it
 
 ## PHP 8.4 Modernization (new in 3.x)
 

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump;
+
+use Druidfi\Mysqldump\Exception\ConnectionException;
+use PDO;
+
+/**
+ * Provides the PDO connection and connection metadata used during a dump.
+ *
+ * The default implementation is DatabaseConnector, which builds a PDO
+ * connection from a DSN string. Implement this interface to supply an
+ * existing PDO instance or a custom connection strategy, and inject it
+ * with Mysqldump::setConnector() before calling start().
+ */
+interface ConnectionInterface
+{
+    /**
+     * Return the PDO connection, establishing it if necessary.
+     * Called once per dump; implementations should return the same
+     * connection on repeated calls.
+     *
+     * @throws ConnectionException when the connection cannot be established
+     */
+    public function connect(): PDO;
+
+    /**
+     * Host name (or socket path) written to the dump file header.
+     */
+    public function getHost(): string;
+
+    /**
+     * Name of the database being dumped; used in SHOW statements and comments.
+     */
+    public function getDbName(): string;
+}

--- a/src/DatabaseConnector.php
+++ b/src/DatabaseConnector.php
@@ -13,7 +13,7 @@ use SensitiveParameter;
  *
  * Handles database connection logic for mysqldump-php.
  */
-class DatabaseConnector
+class DatabaseConnector implements ConnectionInterface
 {
     private string $host;
 

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -29,7 +29,7 @@ use PDO;
 class Mysqldump
 {
     // Database
-    private readonly DatabaseConnector $connector;
+    private ConnectionInterface $connector;
     private ?PDO $conn = null;
     private readonly DumpWriter $writer;
     private TypeAdapterInterface $db;
@@ -79,7 +79,7 @@ class Mysqldump
 
 
     /**
-     * Connect with PDO using the DatabaseConnector.
+     * Connect with PDO using the configured connector.
      *
      * @throws ConnectionException
      */
@@ -705,6 +705,15 @@ class Mysqldump
         }
 
         return $limit;
+    }
+
+    /**
+     * Replace the default DatabaseConnector, e.g. to supply an existing PDO
+     * connection or a custom connection strategy. Must be called before start().
+     */
+    public function setConnector(ConnectionInterface $connector): void
+    {
+        $this->connector = $connector;
     }
 
     /**

--- a/tests/ConnectionInterfaceTest.php
+++ b/tests/ConnectionInterfaceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Druidfi\Mysqldump\Tests;
+
+use Druidfi\Mysqldump\ConnectionInterface;
+use Druidfi\Mysqldump\DatabaseConnector;
+use Druidfi\Mysqldump\Mysqldump;
+use Druidfi\Mysqldump\Tests\Doubles\FakeConnection;
+use Druidfi\Mysqldump\Tests\Doubles\SqliteTypeAdapter;
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Mysqldump::class)]
+#[CoversClass(DatabaseConnector::class)]
+class ConnectionInterfaceTest extends TestCase
+{
+    private string $outputFile;
+
+    protected function setUp(): void
+    {
+        $this->outputFile = tempnam(sys_get_temp_dir(), 'mysqldump-php-test');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->outputFile)) {
+            unlink($this->outputFile);
+        }
+    }
+
+    public function testDatabaseConnectorImplementsConnectionInterface(): void
+    {
+        $connector = new DatabaseConnector('mysql:host=localhost;dbname=test', 'user', 'pass');
+        $this->assertInstanceOf(ConnectionInterface::class, $connector);
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function startDumpWithInjectedSqlite(FakeConnection $connection, array $settings = []): string
+    {
+        $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'user', 'pass', $settings + [
+            // BEGIN/COMMIT and trigger listing are MySQL-specific in the real adapter
+            'single-transaction' => false,
+            'skip-triggers' => true,
+        ]);
+        $dump->setConnector($connection);
+        $dump->addTypeAdapter(SqliteTypeAdapter::class);
+        $dump->start($this->outputFile);
+
+        return file_get_contents($this->outputFile);
+    }
+
+    public function testStartUsesInjectedConnector(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users (id INTEGER, name TEXT)');
+        $pdo->exec("INSERT INTO users VALUES (1, 'John'), (2, 'Jane')");
+        $connection = new FakeConnection($pdo);
+
+        $output = $this->startDumpWithInjectedSqlite($connection, ['skip-comments' => true]);
+
+        $this->assertSame(1, $connection->connectCalls);
+        $this->assertStringContainsString('CREATE TABLE users (id INTEGER, name TEXT);', $output);
+        $this->assertStringContainsString("INSERT INTO `users` VALUES (1,'John'),(2,'Jane');", $output);
+    }
+
+    public function testDumpFileHeaderUsesConnectorMetadata(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $connection = new FakeConnection($pdo, host: 'db.example.test', dbName: 'exampledb');
+
+        $output = $this->startDumpWithInjectedSqlite($connection, ['skip-dump-date' => true]);
+
+        $this->assertStringContainsString("Host: db.example.test\tDatabase: exampledb", $output);
+    }
+}

--- a/tests/Doubles/FakeConnection.php
+++ b/tests/Doubles/FakeConnection.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Druidfi\Mysqldump\Tests\Doubles;
+
+use Druidfi\Mysqldump\ConnectionInterface;
+use PDO;
+
+class FakeConnection implements ConnectionInterface
+{
+    public int $connectCalls = 0;
+
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly string $host = 'fake-host',
+        private readonly string $dbName = 'fakedb',
+    ) {
+    }
+
+    public function connect(): PDO
+    {
+        $this->connectCalls++;
+
+        return $this->pdo;
+    }
+
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    public function getDbName(): string
+    {
+        return $this->dbName;
+    }
+}

--- a/tests/Doubles/SqliteTypeAdapter.php
+++ b/tests/Doubles/SqliteTypeAdapter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Druidfi\Mysqldump\Tests\Doubles;
+
+/**
+ * FakeTypeAdapter variant whose SHOW-statement equivalents are valid SQLite,
+ * so a full Mysqldump::start() run can execute against an in-memory SQLite
+ * connection injected via ConnectionInterface.
+ */
+class SqliteTypeAdapter extends FakeTypeAdapter
+{
+    #[\Override]
+    public function showTables(string $databaseName): string
+    {
+        return "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'";
+    }
+
+    #[\Override]
+    public function showViews(string $databaseName): string
+    {
+        return "SELECT name FROM sqlite_master WHERE type = 'view'";
+    }
+
+    #[\Override]
+    public function showCreateTable(string $tableName): string
+    {
+        return sprintf(
+            "SELECT sql AS 'Create Table' FROM sqlite_master WHERE type = 'table' AND name = '%s'",
+            $tableName
+        );
+    }
+
+    #[\Override]
+    public function createTable(array $row): string
+    {
+        return $row['Create Table'] . ';' . PHP_EOL;
+    }
+
+    #[\Override]
+    public function showColumns(string $tableName): string
+    {
+        return sprintf("SELECT name AS Field, type AS Type FROM pragma_table_info('%s')", $tableName);
+    }
+
+    #[\Override]
+    public function parseColumnType(array $colType): array
+    {
+        $type = strtolower((string) $colType['Type']);
+
+        return [
+            'is_numeric' => str_contains($type, 'int'),
+            'is_blob' => false,
+            'type' => $type,
+            'is_virtual' => false,
+        ];
+    }
+}


### PR DESCRIPTION
## What

Completes task 4 of `docs/tasks.md` (implement interfaces for major components):

- New `src/ConnectionInterface.php` with `connect(): PDO`, `getHost(): string` and `getDbName(): string`; `DatabaseConnector` implements it and remains the default.
- New `Mysqldump::setConnector(ConnectionInterface $connector)` injects a custom implementation before `start()`, mirroring how `addTypeAdapter()` swaps the type adapter. Callers can now reuse an existing PDO instance or supply their own connection strategy, and tests can mock the connector.
- New `tests/ConnectionInterfaceTest.php` proves the seam: a complete `Mysqldump::start()` run against an injected in-memory SQLite connection, using two new test doubles (`FakeConnection`, and `SqliteTypeAdapter` — a `FakeTypeAdapter` whose SHOW-statement equivalents are valid SQLite). This is the first end-to-end test of the dump flow that needs no MySQL server.
- README gains a "Providing your own database connection" section; CLAUDE.md structure/API notes updated and task 4 checked off.

## Why

Task 4 of the improvement roadmap. `DumperInterface` already existed; the connector was the last major component without an interface, which made `start()` untestable without a real MySQL server and prevented reusing an existing PDO connection.

Default behaviour is unchanged — the constructor still builds a `DatabaseConnector` from the DSN/user/pass arguments. The only signature change is the private `$connector` property widening from `DatabaseConnector` to `ConnectionInterface` (and dropping `readonly` to allow the setter).

## Testing

- `vendor/bin/phpunit` — 82 tests, 176 assertions, green (3 new tests)
- `vendor/bin/phpstan --memory-limit=512M` — level 6, no errors
- `vendor/bin/rector process --dry-run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)