### PR TITLE
chore(docker): use php:8.5 GA image instead of 8.5.0beta2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PHP_SHORT_VERSION=84
 
 FROM php:8.4 AS php-84
-FROM php:8.5.0beta2 AS php-85
+FROM php:8.5 AS php-85
 
 FROM php-${PHP_SHORT_VERSION}
 


### PR DESCRIPTION
## What

Replaces the pinned `php:8.5.0beta2` base image in the `php-85` Dockerfile stage with the plain `php:8.5` tag.

## Why

PHP 8.5 has been GA for a long time, but the beta pin kept the local `php85` test container stuck on 8.5.0beta2. The `8.5` tag resolves to the current GA release and tracks patch releases automatically, matching how the `php-84` stage uses `php:8.4`. CI already tests against 8.5 GA via `setup-php`, so this only affects the local Docker test setup.

## Testing

- `docker build --build-arg PHP_SHORT_VERSION=85 .` succeeds; `php -v` in the resulting image reports PHP 8.5.7 (GA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)