### PR TITLE
refactor: dedupe structure extractors and break up TableDataDumper::dump()

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -76,15 +76,22 @@ codebase; items that are done are kept checked for history.
 
 ## Code Quality Improvements
 
-8. [ ] Reduce code duplication:
-   - [ ] Refactor the near-identical `getProcedureStructure()` / `getFunctionStructure()` /
-         `getEventStructure()` / `getTriggerStructure()` "show create + write" pattern
-   - [ ] Extract the repeated comment-header writing (`skipComments()` + sprintf block) into a helper
+8. [x] Reduce code duplication:
+   - [x] Refactor the near-identical `getProcedureStructure()` / `getFunctionStructure()` /
+         `getEventStructure()` / `getTriggerStructure()` "show create + write" pattern into a
+         shared `writeStructureFromShowCreate()` helper — also applied to the table and view
+         structure extractors, which had the same shape
+   - [x] Extract the repeated comment-header writing (`skipComments()` + sprintf block) into
+         `commentBlock()` / `writeComment()` helpers
 
-9. [ ] Improve method organization:
-   - [ ] Break up `TableDataDumper::dump()` (~95 lines, formerly `Mysqldump::listValues()`)
-         into smaller private methods
-   - [ ] Group related methods together in `Mysqldump.php`
+9. [x] Improve method organization:
+   - [x] Break up `TableDataDumper::dump()` (~95 lines, formerly `Mysqldump::listValues()`)
+         into smaller private methods (`buildSelectQuery()` + `writeInsertStatements()`;
+         `dump()` itself is now ~25 lines of orchestration)
+   - [x] Group related methods together in `Mysqldump.php` — `getAdapter()` moved next to
+         `addTypeAdapter()` and the `tableColumnTypes()` accessor next to
+         `getTableColumnTypes()`; the file reads top-down as dump flow → helpers →
+         iterators → structure extractors → public configuration API
 
 10. [x] Enhance type safety (baseline):
     - [x] Add return type declarations to public API methods

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -89,14 +89,51 @@ class Mysqldump
         $this->db = $this->getAdapter($this->conn);
     }
 
-    public function getAdapter(PDO $conn): TypeAdapterInterface
-    {
-        return new ($this->adapterClass)($conn, $this->settings);
-    }
-
     private function write(string $data): int
     {
         return $this->writer->write($data);
+    }
+
+    /**
+     * Format a comment header block, or an empty string when comments are skipped.
+     *
+     * @param string $text Single line of comment text
+     */
+    private function commentBlock(string $text): string
+    {
+        if ($this->settings->skipComments()) {
+            return '';
+        }
+
+        return '--' . PHP_EOL . '-- ' . $text . PHP_EOL . '--' . PHP_EOL . PHP_EOL;
+    }
+
+    /**
+     * Write a comment header block unless comments are skipped.
+     *
+     * @param string $text Single line of comment text
+     */
+    private function writeComment(string $text): void
+    {
+        $this->write($this->commentBlock($text));
+    }
+
+    /**
+     * Run a SHOW CREATE statement and pass its first row to $writeCreate.
+     *
+     * @param string $query SHOW CREATE statement for the object
+     * @param Closure $writeCreate function(array $row): void writes the create statement(s)
+     */
+    private function writeStructureFromShowCreate(string $query, Closure $writeCreate): void
+    {
+        $stmt = $this->conn->query($query);
+
+        foreach ($stmt as $row) {
+            $writeCreate($row);
+            break;
+        }
+
+        $stmt->closeCursor();
     }
 
     /**
@@ -396,32 +433,22 @@ class Mysqldump
     private function getTableStructure(string $tableName): void
     {
         if (!$this->settings->isEnabled('no-create-info')) {
-            $ret = '';
+            // The comment is only written when the table exists, so it is
+            // passed into the closure instead of being written up front.
+            $comment = $this->commentBlock(sprintf('Table structure for table `%s`', $tableName));
 
-            if (!$this->settings->skipComments()) {
-                $ret = sprintf(
-                    "--" . PHP_EOL .
-                    "-- Table structure for table `%s`" . PHP_EOL .
-                    "--" . PHP_EOL . PHP_EOL,
-                    $tableName
-                );
-            }
+            $this->writeStructureFromShowCreate(
+                $this->db->showCreateTable($tableName),
+                function (array $row) use ($tableName, $comment): void {
+                    $this->write($comment);
 
-            $stmt = $this->db->showCreateTable($tableName);
+                    if ($this->settings->isEnabled('add-drop-table')) {
+                        $this->write($this->db->dropTable($tableName));
+                    }
 
-            $stmtCT = $this->conn->query($stmt);
-            foreach ($stmtCT as $r) {
-                $this->write($ret);
-
-                if ($this->settings->isEnabled('add-drop-table')) {
-                    $this->write($this->db->dropTable($tableName));
+                    $this->write($this->db->createTable($row));
                 }
-
-                $this->write($this->db->createTable($r));
-
-                break;
-            }
-            $stmtCT->closeCursor();
+            );
         }
 
         $this->tableColumnTypes[$tableName] = $this->getTableColumnTypes($tableName);
@@ -455,36 +482,35 @@ class Mysqldump
     }
 
     /**
+     * Get table column types.
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    protected function tableColumnTypes(): array
+    {
+        return $this->tableColumnTypes;
+    }
+
+    /**
      * View structure extractor, create table (avoids cyclic references).
      *
      * @param string $viewName Name of view to export
      */
     private function getViewStructureTable(string $viewName): void
     {
-        if (!$this->settings->skipComments()) {
-            $ret = (
-                '--' . PHP_EOL .
-                sprintf('-- Stand-In structure for view `%s`', $viewName) . PHP_EOL .
-                '--' . PHP_EOL . PHP_EOL
-            );
-
-            $this->write($ret);
-        }
-
-        $stmt = $this->db->showCreateView($viewName);
+        $this->writeComment(sprintf('Stand-In structure for view `%s`', $viewName));
 
         // create views as tables, to resolve dependencies
-        $stmtSCV = $this->conn->query($stmt);
-        foreach ($stmtSCV as $r) {
-            if ($this->settings->isEnabled('add-drop-table')) {
-                $this->write($this->db->dropView($viewName));
+        $this->writeStructureFromShowCreate(
+            $this->db->showCreateView($viewName),
+            function (array $row) use ($viewName): void {
+                if ($this->settings->isEnabled('add-drop-table')) {
+                    $this->write($this->db->dropView($viewName));
+                }
+
+                $this->write($this->createStandInTable($viewName));
             }
-
-            $this->write($this->createStandInTable($viewName));
-
-            break;
-        }
-        $stmtSCV->closeCursor();
+        );
     }
 
     /**
@@ -516,29 +542,17 @@ class Mysqldump
      */
     private function getViewStructureView(string $viewName): void
     {
-        if (!$this->settings->skipComments()) {
-            $ret = sprintf(
-                "--" . PHP_EOL .
-                "-- View structure for view `%s`" . PHP_EOL .
-                "--" . PHP_EOL . PHP_EOL,
-                $viewName
-            );
-
-            $this->write($ret);
-        }
-
-        $stmt = $this->db->showCreateView($viewName);
+        $this->writeComment(sprintf('View structure for view `%s`', $viewName));
 
         // Create views, to resolve dependencies replacing tables with views
-        $stmtSCV2 = $this->conn->query($stmt);
-        foreach ($stmtSCV2 as $r) {
-            // Because we must replace table with view, we should delete it
-            $this->write($this->db->dropView($viewName));
-            $this->write($this->db->createView($r));
-
-            break;
-        }
-        $stmtSCV2->closeCursor();
+        $this->writeStructureFromShowCreate(
+            $this->db->showCreateView($viewName),
+            function (array $row) use ($viewName): void {
+                // Because we must replace table with view, we should delete it
+                $this->write($this->db->dropView($viewName));
+                $this->write($this->db->createView($row));
+            }
+        );
     }
 
     /**
@@ -548,20 +562,16 @@ class Mysqldump
      */
     private function getTriggerStructure(string $triggerName): void
     {
-        $stmt = $this->db->showCreateTrigger($triggerName);
+        $this->writeStructureFromShowCreate(
+            $this->db->showCreateTrigger($triggerName),
+            function (array $row) use ($triggerName): void {
+                if ($this->settings->isEnabled('add-drop-trigger')) {
+                    $this->write($this->db->addDropTrigger($triggerName));
+                }
 
-        $stmtSCT = $this->conn->query($stmt);
-        foreach ($stmtSCT as $r) {
-            if ($this->settings->isEnabled('add-drop-trigger')) {
-                $this->write($this->db->addDropTrigger($triggerName));
+                $this->write($this->db->createTrigger($row));
             }
-
-            $this->write($this->db->createTrigger($r));
-
-            $stmtSCT->closeCursor();
-            return;
-        }
-        $stmtSCT->closeCursor();
+        );
     }
 
     /**
@@ -571,22 +581,12 @@ class Mysqldump
      */
     private function getProcedureStructure(string $procedureName): void
     {
-        if (!$this->settings->skipComments()) {
-            $ret = "--" . PHP_EOL .
-                "-- Dumping routines for database '" . $this->connector->getDbName() . "'" . PHP_EOL .
-                "--" . PHP_EOL . PHP_EOL;
-            $this->write($ret);
-        }
+        $this->writeComment("Dumping routines for database '" . $this->connector->getDbName() . "'");
 
-        $stmt = $this->db->showCreateProcedure($procedureName);
-
-        $stmtSCP = $this->conn->query($stmt);
-        foreach ($stmtSCP as $r) {
-            $this->write($this->db->createProcedure($r));
-            $stmtSCP->closeCursor();
-            return;
-        }
-        $stmtSCP->closeCursor();
+        $this->writeStructureFromShowCreate(
+            $this->db->showCreateProcedure($procedureName),
+            fn (array $row): int => $this->write($this->db->createProcedure($row))
+        );
     }
 
     /**
@@ -596,22 +596,12 @@ class Mysqldump
      */
     private function getFunctionStructure(string $functionName): void
     {
-        if (!$this->settings->skipComments()) {
-            $ret = "--" . PHP_EOL .
-                "-- Dumping routines for database '" . $this->connector->getDbName() . "'" . PHP_EOL .
-                "--" . PHP_EOL . PHP_EOL;
-            $this->write($ret);
-        }
+        $this->writeComment("Dumping routines for database '" . $this->connector->getDbName() . "'");
 
-        $stmt = $this->db->showCreateFunction($functionName);
-
-        $stmtSCF = $this->conn->query($stmt);
-        foreach ($stmtSCF as $r) {
-            $this->write($this->db->createFunction($r));
-            $stmtSCF->closeCursor();
-            return;
-        }
-        $stmtSCF->closeCursor();
+        $this->writeStructureFromShowCreate(
+            $this->db->showCreateFunction($functionName),
+            fn (array $row): int => $this->write($this->db->createFunction($row))
+        );
     }
 
     /**
@@ -622,32 +612,12 @@ class Mysqldump
      */
     private function getEventStructure(string $eventName): void
     {
-        if (!$this->settings->skipComments()) {
-            $ret = "--" . PHP_EOL .
-                "-- Dumping events for database '" . $this->connector->getDbName() . "'" . PHP_EOL .
-                "--" . PHP_EOL . PHP_EOL;
-            $this->write($ret);
-        }
+        $this->writeComment("Dumping events for database '" . $this->connector->getDbName() . "'");
 
-        $stmt = $this->db->showCreateEvent($eventName);
-
-        $stmtSCE = $this->conn->query($stmt);
-        foreach ($stmtSCE as $r) {
-            $this->write($this->db->createEvent($r));
-            $stmtSCE->closeCursor();
-            return;
-        }
-        $stmtSCE->closeCursor();
-    }
-
-    /**
-     * Get table column types.
-     *
-     * @return array<string, array<string, array<string, mixed>>>
-     */
-    protected function tableColumnTypes(): array
-    {
-        return $this->tableColumnTypes;
+        $this->writeStructureFromShowCreate(
+            $this->db->showCreateEvent($eventName),
+            fn (array $row): int => $this->write($this->db->createEvent($row))
+        );
     }
 
     /**
@@ -730,6 +700,11 @@ class Mysqldump
         }
 
         $this->adapterClass = $adapterClassName;
+    }
+
+    public function getAdapter(PDO $conn): TypeAdapterInterface
+    {
+        return new ($this->adapterClass)($conn, $this->settings);
     }
 
     /**

--- a/src/TableDataDumper.php
+++ b/src/TableDataDumper.php
@@ -50,41 +50,79 @@ class TableDataDumper
     {
         $this->prepareListValues($tableName);
 
-        $onlyOnce = true;
-        $colNames = [];
         $columnTypes = ($this->getColumnTypes)($tableName);
 
         // getting the column statement has side effect, so we backup this setting for consitency
         $completeInsertBackup = $this->settings->isEnabled('complete-insert');
 
+        $query = $this->buildSelectQuery($tableName, $columnTypes);
+
+        // colNames is used to get the name of the columns when using complete-insert;
+        // resolved after buildSelectQuery() because getColumnStmt() enables
+        // complete-insert when the table has virtual columns
+        $colNames = $this->settings->isEnabled('complete-insert') ? $this->getColumnNames($columnTypes) : [];
+
+        $count = $this->writeInsertStatements($tableName, $query, $columnTypes, $colNames);
+
+        $this->endListValues($tableName, $count);
+
+        if ($this->info !== null) {
+            ($this->info)('table', ['name' => $tableName, 'completed' => true, 'rowCount' => $count]);
+        }
+
+        $this->settings->setCompleteInsert($completeInsertBackup);
+    }
+
+    /**
+     * Build the SELECT statement used to read the table rows, applying the
+     * per-table (or default) WHERE condition and LIMIT.
+     *
+     * @param string $tableName Name of table to export
+     * @param array<string, array<string, mixed>> $columnTypes Column type info for the table
+     */
+    private function buildSelectQuery(string $tableName, array $columnTypes): string
+    {
         // colStmt is used to form a query to obtain row values
         $colStmt = $this->getColumnStmt($columnTypes);
 
-        // colNames is used to get the name of the columns when using complete-insert
-        if ($this->settings->isEnabled('complete-insert')) {
-            $colNames = $this->getColumnNames($columnTypes);
-        }
-
-        $stmt = "SELECT " . implode(",", $colStmt) . " FROM `$tableName`";
+        $query = "SELECT " . implode(",", $colStmt) . " FROM `$tableName`";
 
         // Table specific conditions override the default 'where'
         $condition = ($this->getTableWhere)($tableName);
 
         if ($condition) {
-            $stmt .= sprintf(' WHERE %s', $condition);
+            $query .= sprintf(' WHERE %s', $condition);
         }
 
         if ($limit = ($this->getTableLimit)($tableName)) {
-            $stmt .= is_numeric($limit) ?
+            $query .= is_numeric($limit) ?
                 sprintf(' LIMIT %d', $limit) :
                 sprintf(' LIMIT %s', $limit);
         }
 
-        $resultSet = $this->conn->query($stmt);
+        return $query;
+    }
+
+    /**
+     * Run the SELECT query and write the rows as INSERT/REPLACE statements,
+     * flushing a statement whenever it exceeds net_buffer_length (or per row
+     * when extended-insert is off). Reports progress through the info hook.
+     *
+     * @param string $tableName Name of table to export
+     * @param string $query SELECT statement reading the rows
+     * @param array<string, array<string, mixed>> $columnTypes Column type info for the table
+     * @param string[] $colNames Quoted column names for complete-insert, empty otherwise
+     * @return int Number of rows dumped
+     * @throws DumpException
+     */
+    private function writeInsertStatements(string $tableName, string $query, array $columnTypes, array $colNames): int
+    {
+        $resultSet = $this->conn->query($query);
         $resultSet->setFetchMode(PDO::FETCH_ASSOC);
 
         $insertType = $this->getInsertType()->value;
         $count = 0;
+        $onlyOnce = true;
 
         $isInfoCallable = $this->info !== null;
         if ($isInfoCallable) {
@@ -132,13 +170,7 @@ class TableDataDumper
             $this->writer->write($line. ';' . PHP_EOL);
         }
 
-        $this->endListValues($tableName, $count);
-
-        if ($isInfoCallable) {
-            ($this->info)('table', ['name' => $tableName, 'completed' => true, 'rowCount' => $count]);
-        }
-
-        $this->settings->setCompleteInsert($completeInsertBackup);
+        return $count;
     }
 
     private function getInsertType(): InsertType


### PR DESCRIPTION
## What

Completes tasks 8 and 9 of `docs/tasks.md` in one PR. No behaviour change intended — dump output is byte-identical.

**Task 8 — reduce code duplication (`Mysqldump`):**
- New `writeStructureFromShowCreate()` helper owns the "query SHOW CREATE, write the first row" pattern that was copy-pasted across `getTriggerStructure()`, `getProcedureStructure()`, `getFunctionStructure()` and `getEventStructure()`. The table and both view structure extractors had the same shape, so they use it too — six duplicated query/loop/closeCursor blocks collapse into one.
- New `commentBlock()`/`writeComment()` helpers replace the six repeated `skipComments()` + sprintf comment-header blocks. `getTableStructure()` uses the string-returning `commentBlock()` variant because its header is only written when the table actually exists (inside the show-create closure).

**Task 9 — method organization:**
- `TableDataDumper::dump()` (~95 lines) split into `buildSelectQuery()` (SELECT + WHERE + LIMIT building) and `writeInsertStatements()` (row loop, net_buffer_length flushing, info-hook reporting). `dump()` is now ~25 lines of orchestration. One ordering subtlety preserved: `$colNames` is resolved *after* the select build because `getColumnStmt()` enables `complete-insert` when the table has virtual columns.
- Light regrouping in `Mysqldump.php`: `getAdapter()` moved next to `addTypeAdapter()`, the `tableColumnTypes()` accessor next to `getTableColumnTypes()`. The file now reads top-down: dump flow → write helpers → iterators → structure extractors → public configuration API.

## Why

Tasks 8 and 9 of the improvement roadmap — the remaining "Code Quality" refactors after the TableDataDumper extraction (#91). The four structure extractors were near-identical, and `dump()` was the last ~95-line method in the codebase.

## Testing

- Integration suite (byte-for-byte vs native mysqldump, 39 comparisons incl. triggers, procedures, functions and events via test010/test012 fixtures): passes on PHP 8.4 × MySQL 8.0 / MySQL 8.4 / MariaDB 10.11 and PHP 8.5 × MySQL 8.0
- `vendor/bin/phpunit` — 82 tests, 176 assertions, green
- `vendor/bin/phpstan --memory-limit=512M` — level 6, no errors
- `vendor/bin/rector process --dry-run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)