### PR TITLE
fix: return actual types from DumpSettings::get() instead of string cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ from 2.x. The following changes may require action:
   use the native PHP 8.4 `#[\Deprecated]` attribute.
 - **`ConfigValidator::checkDeprecated()` return value changed.** The `reason` and `alternative`
   keys were replaced by a single `message` key (`deprecated` and `since` are unchanged).
+- **`DumpSettings::get()` returns the setting's actual type.** In 2.x every value was cast to
+  `string`; now arrays, booleans and integers come back unchanged, and unknown options return
+  `null` instead of the string `""`. Prefer the typed getters (`getWhere()`,
+  `getNetBufferLength()`, ...) where one exists.
 - **`compress-level` is validated per method.** Levels up to the method maximum are accepted
   (Gzip 1-9, Lz4 1-12, Zstd 1-22) where 2.x rejected everything above 9, and a level above the
   method maximum now throws with a method-specific message.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -102,8 +102,9 @@ codebase; items that are done are kept checked for history.
 11. [ ] Implement better validation:
     - [x] `matches()` reads `$pattern[0]` — an empty string in include/exclude/no-data arrays causes
           an error (fixed via `str_starts_with()` in the `array_any()` rewrite)
-    - [ ] Fix `DumpSettings::get()` casting every setting to `string` — return proper types or add
-          typed getters
+    - [x] Fix `DumpSettings::get()` casting every setting to `string` — `get()` now returns the
+          raw value as `mixed` (`null` for unknown options) and the one string consumer uses a
+          new `getWhere()` typed getter; documented as a breaking change in the README
     - [x] Validate `net_buffer_length` and other numeric settings via `Constraint` attributes
           (`net_buffer_length` has `min: 1024`, `compress-level` has `min: 0, max: 22` —
           the only two numeric options)

--- a/src/DumpSettings.php
+++ b/src/DumpSettings.php
@@ -81,7 +81,7 @@ class DumpSettings
 
         $this->settings = array_replace_recursive(self::$defaults, $settings);
 
-        $this->settings['init_commands'][] = "SET NAMES " . $this->get('default-character-set');
+        $this->settings['init_commands'][] = "SET NAMES " . $this->getDefaultCharacterSet();
 
         if (false === $this->settings['skip-tz-utc']) {
             $this->settings['init_commands'][] = "SET TIME_ZONE='+00:00'";
@@ -232,8 +232,17 @@ class DumpSettings
         return $this->isEnabled('skip-tz-utc');
     }
 
-    public function get(string $option): string
+    /**
+     * Return the raw value of a setting in its actual type.
+     * Prefer the typed getters where one exists.
+     */
+    public function get(string $option): mixed
     {
-        return (string) $this->settings[$option];
+        return $this->settings[$option] ?? null;
+    }
+
+    public function getWhere(): string
+    {
+        return (string) $this->settings['where'];
     }
 }

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -635,8 +635,8 @@ class Mysqldump
     {
         if (!empty($this->tableWheres[$tableName])) {
             return $this->tableWheres[$tableName];
-        } elseif ($this->settings->get('where')) {
-            return $this->settings->get('where');
+        } elseif ($this->settings->getWhere()) {
+            return $this->settings->getWhere();
         }
 
         return false;

--- a/tests/DumpSettingsTest.php
+++ b/tests/DumpSettingsTest.php
@@ -171,13 +171,31 @@ class DumpSettingsTest extends TestCase
     }
     
     /**
-     * Test the get method
+     * Test that the get method returns values in their actual type
      */
     public function testGetMethod(): void
     {
-        $settings = new DumpSettings(['net_buffer_length' => 500000]);
-        
-        $this->assertEquals('500000', $settings->get('net_buffer_length'));
+        $settings = new DumpSettings([
+            'net_buffer_length' => 500000,
+            'exclude-tables' => ['logs'],
+        ]);
+
+        $this->assertSame(500000, $settings->get('net_buffer_length'));
+        $this->assertSame(['logs'], $settings->get('exclude-tables'));
+        $this->assertFalse($settings->get('complete-insert'));
+        $this->assertNull($settings->get('unknown-option'));
+    }
+
+    /**
+     * Test the getWhere typed getter
+     */
+    public function testGetWhere(): void
+    {
+        $settings = new DumpSettings([]);
+        $this->assertSame('', $settings->getWhere());
+
+        $settings = new DumpSettings(['where' => 'id > 100']);
+        $this->assertSame('id > 100', $settings->getWhere());
     }
     
     /**


### PR DESCRIPTION
## What

Completes task 11 of `docs/tasks.md` (implement better validation) — the last open item in that task.

- `DumpSettings::get()` no longer casts every setting to `string`: it returns the raw value as `mixed`, and `null` for unknown options (previously an undefined-key warning plus `""`).
- New `getWhere(): string` typed getter for the one place that consumed `get()` as a string; `Mysqldump::getTableWhere()` uses it now, and the constructor's `SET NAMES` line uses the existing `getDefaultCharacterSet()` getter.
- `DumpSettingsTest::testGetMethod()` — which pinned the old behavior by asserting `'500000'` (string) for an int setting — now asserts real types for int, array, bool and unknown options, plus new `getWhere()` coverage.
- README upgrade section documents the signature change, since 2.x shipped `get(): string`.

## Why

The string cast made `get()`'s return type a lie for most of the ~30 options: arrays (`include-tables`, `init_commands`) would fatal on cast, booleans came back as `""`/`"1"`, and integers as numeric strings. Internal callers only ever used it for `where`, so the fix is a typed getter there and honest types from the generic accessor.

Behaviour of the dump itself is unchanged — `getTableWhere()` keeps the same truthy check on the `where` string.

## Testing

- `vendor/bin/phpunit` — 83 tests, 181 assertions, green
- `vendor/bin/phpstan --memory-limit=512M` — level 6, no errors
- `vendor/bin/rector process --dry-run` — clean
- Integration sanity run against MySQL 8.0 (39 byte-for-byte comparisons incl. the where-clause filtered dumps) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)