### PR TITLE
fix: escape identifiers consistently when interpolated into SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ from 2.x. The following changes may require action:
   `string`; now arrays, booleans and integers come back unchanged, and unknown options return
   `null` instead of the string `""`. Prefer the typed getters (`getWhere()`,
   `getNetBufferLength()`, ...) where one exists.
+- **`TypeAdapterInterface` gained `quoteIdentifier()`.** Identifiers (table, view, column, ...
+  names) are now escaped wherever they are interpolated into SQL, so names containing backticks
+  dump correctly. Custom type adapters must implement the new method.
 - **`compress-level` is validated per method.** Levels up to the method maximum are accepted
   (Gzip 1-9, Lz4 1-12, Zstd 1-22) where 2.x rejected everything above 9, and a level above the
   method maximum now throws with a method-specific message.
@@ -188,6 +191,12 @@ $dumper->setTableWheres([
 ]);
 ```
 
+> [!WARNING]
+> The `where` dump setting, `setTableWheres()` and `setTableLimits()` values are inserted into
+> the dump's `SELECT` statements as raw SQL by design — that is what makes arbitrary conditions
+> possible. They are not escaped or validated, so never build them from untrusted input
+> (request parameters, user-supplied data, etc.).
+
 ## Table specific export limits
 
 You can register table specific 'limits' to limit the returned rows on a per table basis:
@@ -301,6 +310,7 @@ All options:
   - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqlpump.html#option_mysqlpump_skip-definer)
 - **where**
   - MySQL docs [8.0](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_where)
+  - Raw SQL by design — see the warning under [Table specific export conditions](#table-specific-export-conditions)
 
 The following option is deprecated. Passing it triggers a deprecation notice, and it will be removed
 in a future version; use `init_commands` to control `FOREIGN_KEY_CHECKS` manually if needed.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -157,12 +157,15 @@ codebase; items that are done are kept checked for history.
 
 ## Security Improvements
 
-18. [ ] Harden identifier and input handling (classic prepared statements don't apply to
+18. [x] Harden identifier and input handling (classic prepared statements don't apply to
         identifiers or to a dump tool's SHOW/SELECT flow):
-    - [ ] Escape/validate table names consistently when interpolated into SQL
-          (e.g. `` `$tableName` `` in `listValues()`; a name containing a backtick would break the query)
-    - [ ] Document that `where`, `tableWheres` and `tableLimits` are raw SQL by design and must not
-          contain untrusted input
+    - [x] Escape/validate table names consistently when interpolated into SQL —
+          `quoteIdentifier()` added to `TypeAdapterInterface` (backtick-doubling in
+          `TypeAdapterMysql`) and applied to every identifier interpolation: SELECT/INSERT in
+          `TableDataDumper`, SHOW CREATE/DROP/LOCK/ALTER in `TypeAdapterMysql`, Stand-In tables;
+          INFORMATION_SCHEMA database-name string literals now go through `PDO::quote()`
+    - [x] Document that `where`, `tableWheres` and `tableLimits` are raw SQL by design and must not
+          contain untrusted input (README warning + setter docblocks + `ConfigOption` description)
 
 19. [ ] Improve security posture of the project:
     - [ ] Add a SECURITY.md with a vulnerability reporting policy

--- a/src/ConfigOption.php
+++ b/src/ConfigOption.php
@@ -122,7 +122,7 @@ class ConfigOption
     #[DefaultValue(value: false, description: 'Skip DEFINER clauses')]
     public const string SKIP_DEFINER = 'skip-definer';
 
-    #[DefaultValue(value: '', description: 'WHERE clause for filtering data')]
+    #[DefaultValue(value: '', description: 'WHERE clause for filtering data (raw SQL, must not contain untrusted input)')]
     public const string WHERE = 'where';
 
     #[DefaultValue(value: true, description: 'Disable foreign key checks (deprecated)')]

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -435,7 +435,10 @@ class Mysqldump
         if (!$this->settings->isEnabled('no-create-info')) {
             // The comment is only written when the table exists, so it is
             // passed into the closure instead of being written up front.
-            $comment = $this->commentBlock(sprintf('Table structure for table `%s`', $tableName));
+            // Native mysqldump quotes identifiers in comment headers too.
+            $comment = $this->commentBlock(
+                sprintf('Table structure for table %s', $this->db->quoteIdentifier($tableName))
+            );
 
             $this->writeStructureFromShowCreate(
                 $this->db->showCreateTable($tableName),
@@ -498,7 +501,7 @@ class Mysqldump
      */
     private function getViewStructureTable(string $viewName): void
     {
-        $this->writeComment(sprintf('Stand-In structure for view `%s`', $viewName));
+        $this->writeComment(sprintf('Stand-In structure for view %s', $this->db->quoteIdentifier($viewName)));
 
         // create views as tables, to resolve dependencies
         $this->writeStructureFromShowCreate(
@@ -525,14 +528,14 @@ class Mysqldump
         $ret = [];
 
         foreach ($this->tableColumnTypes[$viewName] as $k => $v) {
-            $ret[] = sprintf('`%s` %s', $k, $v['type_sql']);
+            $ret[] = sprintf('%s %s', $this->db->quoteIdentifier((string) $k), $v['type_sql']);
         }
 
         $ret = implode(PHP_EOL . ',', $ret);
 
         return sprintf(
-            "CREATE TABLE IF NOT EXISTS `%s` (" . PHP_EOL . "%s" . PHP_EOL . ");" . PHP_EOL,
-            $viewName,
+            "CREATE TABLE IF NOT EXISTS %s (" . PHP_EOL . "%s" . PHP_EOL . ");" . PHP_EOL,
+            $this->db->quoteIdentifier($viewName),
             $ret
         );
     }
@@ -542,7 +545,7 @@ class Mysqldump
      */
     private function getViewStructureView(string $viewName): void
     {
-        $this->writeComment(sprintf('View structure for view `%s`', $viewName));
+        $this->writeComment(sprintf('View structure for view %s', $this->db->quoteIdentifier($viewName)));
 
         // Create views, to resolve dependencies replacing tables with views
         $this->writeStructureFromShowCreate(
@@ -624,6 +627,9 @@ class Mysqldump
      * Keyed by table name, with the value as the conditions:
      * e.g. 'users' => 'date_registered > NOW() - INTERVAL 6 MONTH AND deleted=0'
      *
+     * The conditions are inserted into the SELECT statements as raw SQL by
+     * design and must not contain untrusted input.
+     *
      * @param array<string, string> $tableWheres
      */
     public function setTableWheres(array $tableWheres): void
@@ -644,6 +650,10 @@ class Mysqldump
 
     /**
      * Keyed by table name, with the value as the numeric limit: e.g. 'users' => 3000
+     *
+     * Non-numeric values are ignored (see getTableLimit()), but the resulting
+     * LIMIT is inserted into the SELECT statements as raw SQL by design and
+     * must not contain untrusted input.
      *
      * @param array<string, mixed> $tableLimits
      */

--- a/src/TableDataDumper.php
+++ b/src/TableDataDumper.php
@@ -85,7 +85,7 @@ class TableDataDumper
         // colStmt is used to form a query to obtain row values
         $colStmt = $this->getColumnStmt($columnTypes);
 
-        $query = "SELECT " . implode(",", $colStmt) . " FROM `$tableName`";
+        $query = "SELECT " . implode(",", $colStmt) . " FROM " . $this->db->quoteIdentifier($tableName);
 
         // Table specific conditions override the default 'where'
         $condition = ($this->getTableWhere)($tableName);
@@ -138,14 +138,19 @@ class TableDataDumper
             if ($onlyOnce || !$this->settings->isEnabled('extended-insert')) {
                 if ($this->settings->isEnabled('complete-insert') && count($colNames)) {
                     $line .= sprintf(
-                        '%s INTO `%s` (%s) VALUES (%s)',
+                        '%s INTO %s (%s) VALUES (%s)',
                         $insertType,
-                        $tableName,
+                        $this->db->quoteIdentifier($tableName),
                         implode(', ', $colNames),
                         $valueList
                     );
                 } else {
-                    $line .= sprintf('%s INTO `%s` VALUES (%s)', $insertType, $tableName, $valueList);
+                    $line .= sprintf(
+                        '%s INTO %s VALUES (%s)',
+                        $insertType,
+                        $this->db->quoteIdentifier($tableName),
+                        $valueList
+                    );
                 }
                 $onlyOnce = false;
             } else {
@@ -195,9 +200,10 @@ class TableDataDumper
     private function prepareListValues(string $tableName): void
     {
         if (!$this->settings->skipComments()) {
+            // Native mysqldump quotes identifiers in comment headers too
             $this->writer->write(
                 "--" . PHP_EOL .
-                "-- Dumping data for table `$tableName`" . PHP_EOL .
+                "-- Dumping data for table " . $this->db->quoteIdentifier($tableName) . PHP_EOL .
                 "--" . PHP_EOL . PHP_EOL
             );
         }
@@ -251,7 +257,7 @@ class TableDataDumper
 
         if (!$this->settings->skipComments()) {
             $this->writer->write(
-                "-- Dumped table `" . $tableName . "` with $count row(s)" . PHP_EOL .
+                "-- Dumped table " . $this->db->quoteIdentifier($tableName) . " with $count row(s)" . PHP_EOL .
                 '--' . PHP_EOL . PHP_EOL
             );
         }
@@ -315,17 +321,19 @@ class TableDataDumper
     {
         $colStmt = [];
         foreach ($columnTypes as $colName => $colType) {
+            $quotedColName = $this->db->quoteIdentifier((string) $colName);
+
             if ($colType['is_virtual']) {
                 $this->settings->setCompleteInsert();
             } elseif ($colType['type'] == 'double') {
                 // PHP 8.1+ returns double fields with float precision issues; dump via CONCAT
-                $colStmt[] = sprintf("CONCAT(`%s`) AS `%s`", $colName, $colName);
+                $colStmt[] = sprintf("CONCAT(%s) AS %s", $quotedColName, $quotedColName);
             } elseif ($colType['type'] === 'bit' && $this->settings->isEnabled('hex-blob')) {
-                $colStmt[] = sprintf("LPAD(HEX(`%s`),2,'0') AS `%s`", $colName, $colName);
+                $colStmt[] = sprintf("LPAD(HEX(%s),2,'0') AS %s", $quotedColName, $quotedColName);
             } elseif ($colType['is_blob'] && $this->settings->isEnabled('hex-blob')) {
-                $colStmt[] = sprintf("HEX(`%s`) AS `%s`", $colName, $colName);
+                $colStmt[] = sprintf("HEX(%s) AS %s", $quotedColName, $quotedColName);
             } else {
-                $colStmt[] = sprintf("`%s`", $colName);
+                $colStmt[] = $quotedColName;
             }
         }
 
@@ -346,7 +354,7 @@ class TableDataDumper
             if ($colType['is_virtual']) {
                 $this->settings->setCompleteInsert();
             } else {
-                $colNames[] = sprintf('`%s`', $colName);
+                $colNames[] = $this->db->quoteIdentifier((string) $colName);
             }
         }
 

--- a/src/TypeAdapter/TypeAdapterInterface.php
+++ b/src/TypeAdapter/TypeAdapterInterface.php
@@ -43,6 +43,12 @@ interface TypeAdapterInterface
      */
     public function parseColumnType(array $colType): array;
 
+    /**
+     * Quote an identifier (table, view, column, ... name) for safe interpolation
+     * into SQL, escaping any quoting characters the name itself contains.
+     */
+    public function quoteIdentifier(string $identifier): string;
+
     public function restoreParameters(): string;
     public function setupTransaction(): string;
     public function showColumns(string $tableName): string;

--- a/src/TypeAdapter/TypeAdapterMysql.php
+++ b/src/TypeAdapter/TypeAdapterMysql.php
@@ -54,6 +54,15 @@ class TypeAdapterMysql implements TypeAdapterInterface
         }
     }
 
+    /**
+     * Quote an identifier MySQL-style: wrap in backticks and double any
+     * backtick the name itself contains.
+     */
+    public function quoteIdentifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+
     public function databases(string $databaseName): string
     {
         $stmt = $this->db->query("SHOW VARIABLES LIKE 'character_set_database';");
@@ -65,45 +74,45 @@ class TypeAdapterMysql implements TypeAdapterInterface
         $stmt->closeCursor();
 
         return sprintf(
-            "CREATE DATABASE /*!32312 IF NOT EXISTS*/ `%s`" .
+            "CREATE DATABASE /*!32312 IF NOT EXISTS*/ %s" .
             " /*!40100 DEFAULT CHARACTER SET %s " .
             " COLLATE %s */;" . PHP_EOL . PHP_EOL .
-            "USE `%s`;" . PHP_EOL . PHP_EOL,
-            $databaseName,
+            "USE %s;" . PHP_EOL . PHP_EOL,
+            $this->quoteIdentifier($databaseName),
             $characterSet,
             $collation,
-            $databaseName
+            $this->quoteIdentifier($databaseName)
         );
     }
 
     public function showCreateTable(string $tableName): string
     {
-        return "SHOW CREATE TABLE `$tableName`";
+        return "SHOW CREATE TABLE " . $this->quoteIdentifier($tableName);
     }
 
     public function showCreateView(string $viewName): string
     {
-        return "SHOW CREATE VIEW `$viewName`";
+        return "SHOW CREATE VIEW " . $this->quoteIdentifier($viewName);
     }
 
     public function showCreateTrigger(string $triggerName): string
     {
-        return "SHOW CREATE TRIGGER `$triggerName`";
+        return "SHOW CREATE TRIGGER " . $this->quoteIdentifier($triggerName);
     }
 
     public function showCreateProcedure(string $procedureName): string
     {
-        return "SHOW CREATE PROCEDURE `$procedureName`";
+        return "SHOW CREATE PROCEDURE " . $this->quoteIdentifier($procedureName);
     }
 
     public function showCreateFunction(string $functionName): string
     {
-        return "SHOW CREATE FUNCTION `$functionName`";
+        return "SHOW CREATE FUNCTION " . $this->quoteIdentifier($functionName);
     }
 
     public function showCreateEvent(string $eventName): string
     {
-        return "SHOW CREATE EVENT `$eventName`";
+        return "SHOW CREATE EVENT " . $this->quoteIdentifier($eventName);
     }
 
     /**
@@ -216,8 +225,8 @@ class TypeAdapterMysql implements TypeAdapterInterface
             }
         }
 
-        $ret .= "/*!50003 DROP PROCEDURE IF EXISTS `".
-            $row['Procedure']."` */;".PHP_EOL.
+        $ret .= "/*!50003 DROP PROCEDURE IF EXISTS ".
+            $this->quoteIdentifier((string) $row['Procedure'])." */;".PHP_EOL.
             "/*!40101 SET @saved_cs_client     = @@character_set_client */;".PHP_EOL.
             "/*!40101 SET character_set_client = ".$this->settings->getDefaultCharacterSet()." */;".PHP_EOL.
             "DELIMITER ;;".PHP_EOL.
@@ -255,8 +264,8 @@ class TypeAdapterMysql implements TypeAdapterInterface
             }
         }
 
-        $ret .= "/*!50003 DROP FUNCTION IF EXISTS `".
-            $row['Function']."` */;".PHP_EOL.
+        $ret .= "/*!50003 DROP FUNCTION IF EXISTS ".
+            $this->quoteIdentifier((string) $row['Function'])." */;".PHP_EOL.
             "/*!40101 SET @saved_cs_client     = @@character_set_client */;".PHP_EOL.
             "/*!50003 SET @saved_cs_results     = @@character_set_results */ ;".PHP_EOL.
             "/*!50003 SET @saved_col_connection = @@collation_connection */ ;".PHP_EOL.
@@ -307,7 +316,7 @@ class TypeAdapterMysql implements TypeAdapterInterface
         }
 
         $ret .= "/*!50106 SET @save_time_zone= @@TIME_ZONE */ ;".PHP_EOL.
-            "/*!50106 DROP EVENT IF EXISTS `".$eventName."` */;".PHP_EOL.
+            "/*!50106 DROP EVENT IF EXISTS ".$this->quoteIdentifier((string) $eventName)." */;".PHP_EOL.
             "DELIMITER ;;".PHP_EOL.
             "/*!50003 SET @saved_cs_client      = @@character_set_client */ ;;".PHP_EOL.
             "/*!50003 SET @saved_cs_results     = @@character_set_results */ ;;".PHP_EOL.
@@ -338,9 +347,9 @@ class TypeAdapterMysql implements TypeAdapterInterface
         return sprintf(
             "SELECT TABLE_NAME AS tbl_name ".
             "FROM INFORMATION_SCHEMA.TABLES ".
-            "WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA='%s' ".
+            "WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA=%s ".
             "ORDER BY TABLE_NAME",
-            $databaseName
+            $this->db->quote($databaseName)
         );
     }
 
@@ -349,20 +358,20 @@ class TypeAdapterMysql implements TypeAdapterInterface
         return sprintf(
             "SELECT TABLE_NAME AS tbl_name ".
             "FROM INFORMATION_SCHEMA.TABLES ".
-            "WHERE TABLE_TYPE='VIEW' AND TABLE_SCHEMA='%s' ".
+            "WHERE TABLE_TYPE='VIEW' AND TABLE_SCHEMA=%s ".
             "ORDER BY TABLE_NAME",
-            $databaseName
+            $this->db->quote($databaseName)
         );
     }
 
     public function showTriggers(string $databaseName): string
     {
-        return sprintf("SHOW TRIGGERS FROM `%s`;", $databaseName);
+        return sprintf("SHOW TRIGGERS FROM %s;", $this->quoteIdentifier($databaseName));
     }
 
     public function showColumns(string $tableName): string
     {
-        return sprintf("SHOW COLUMNS FROM `%s`;", $tableName);
+        return sprintf("SHOW COLUMNS FROM %s;", $this->quoteIdentifier($tableName));
     }
 
     public function showProcedures(string $databaseName): string
@@ -370,8 +379,8 @@ class TypeAdapterMysql implements TypeAdapterInterface
         return sprintf(
             "SELECT SPECIFIC_NAME AS procedure_name ".
             "FROM INFORMATION_SCHEMA.ROUTINES ".
-            "WHERE ROUTINE_TYPE='PROCEDURE' AND ROUTINE_SCHEMA='%s'",
-            $databaseName
+            "WHERE ROUTINE_TYPE='PROCEDURE' AND ROUTINE_SCHEMA=%s",
+            $this->db->quote($databaseName)
         );
     }
 
@@ -380,8 +389,8 @@ class TypeAdapterMysql implements TypeAdapterInterface
         return sprintf(
             "SELECT SPECIFIC_NAME AS function_name ".
             "FROM INFORMATION_SCHEMA.ROUTINES ".
-            "WHERE ROUTINE_TYPE='FUNCTION' AND ROUTINE_SCHEMA='%s'",
-            $databaseName
+            "WHERE ROUTINE_TYPE='FUNCTION' AND ROUTINE_SCHEMA=%s",
+            $this->db->quote($databaseName)
         );
     }
 
@@ -393,8 +402,8 @@ class TypeAdapterMysql implements TypeAdapterInterface
         return sprintf(
             "SELECT EVENT_NAME AS event_name ".
             "FROM INFORMATION_SCHEMA.EVENTS ".
-            "WHERE EVENT_SCHEMA='%s'",
-            $databaseName
+            "WHERE EVENT_SCHEMA=%s",
+            $this->db->quote($databaseName)
         );
     }
 
@@ -416,7 +425,7 @@ class TypeAdapterMysql implements TypeAdapterInterface
 
     public function lockTable(string $tableName): void
     {
-        $this->db->exec(sprintf("LOCK TABLES `%s` READ LOCAL", $tableName));
+        $this->db->exec(sprintf("LOCK TABLES %s READ LOCAL", $this->quoteIdentifier($tableName)));
     }
 
     public function unlockTable(string $tableName): void
@@ -426,7 +435,7 @@ class TypeAdapterMysql implements TypeAdapterInterface
 
     public function startAddLockTable(string $tableName): string
     {
-        return sprintf("LOCK TABLES `%s` WRITE;" . PHP_EOL, $tableName);
+        return sprintf("LOCK TABLES %s WRITE;" . PHP_EOL, $this->quoteIdentifier($tableName));
     }
 
     public function endAddLockTable(string $tableName): string
@@ -436,12 +445,12 @@ class TypeAdapterMysql implements TypeAdapterInterface
 
     public function startAddDisableKeys(string $tableName): string
     {
-        return sprintf("/*!40000 ALTER TABLE `%s` DISABLE KEYS */;". PHP_EOL, $tableName);
+        return sprintf("/*!40000 ALTER TABLE %s DISABLE KEYS */;". PHP_EOL, $this->quoteIdentifier($tableName));
     }
 
     public function endAddDisableKeys(string $tableName): string
     {
-        return sprintf("/*!40000 ALTER TABLE `%s` ENABLE KEYS */;". PHP_EOL, $tableName);
+        return sprintf("/*!40000 ALTER TABLE %s ENABLE KEYS */;". PHP_EOL, $this->quoteIdentifier($tableName));
     }
 
     public function startDisableAutocommit(): string
@@ -456,26 +465,26 @@ class TypeAdapterMysql implements TypeAdapterInterface
 
     public function addDropDatabase(string $databaseName): string
     {
-        return sprintf("/*!40000 DROP DATABASE IF EXISTS `%s`*/;". PHP_EOL.PHP_EOL, $databaseName);
+        return sprintf("/*!40000 DROP DATABASE IF EXISTS %s*/;". PHP_EOL.PHP_EOL, $this->quoteIdentifier($databaseName));
     }
 
     public function addDropTrigger(string $triggerName): string
     {
-        return sprintf("DROP TRIGGER IF EXISTS `%s`;".PHP_EOL, $triggerName);
+        return sprintf("DROP TRIGGER IF EXISTS %s;".PHP_EOL, $this->quoteIdentifier($triggerName));
     }
 
     public function dropTable(string $tableName): string
     {
-        return sprintf("DROP TABLE IF EXISTS `%s`;".PHP_EOL, $tableName);
+        return sprintf("DROP TABLE IF EXISTS %s;".PHP_EOL, $this->quoteIdentifier($tableName));
     }
 
     public function dropView(string $viewName): string
     {
         return sprintf(
-            "DROP TABLE IF EXISTS `%s`;".PHP_EOL.
-            "/*!50001 DROP VIEW IF EXISTS `%s`*/;".PHP_EOL,
-            $viewName,
-            $viewName
+            "DROP TABLE IF EXISTS %s;".PHP_EOL.
+            "/*!50001 DROP VIEW IF EXISTS %s*/;".PHP_EOL,
+            $this->quoteIdentifier($viewName),
+            $this->quoteIdentifier($viewName)
         );
     }
 

--- a/tests/Doubles/FakeTypeAdapter.php
+++ b/tests/Doubles/FakeTypeAdapter.php
@@ -34,6 +34,7 @@ class FakeTypeAdapter implements TypeAdapterInterface
     public function getVersion(): string { return 'fake'; }
     public function lockTable(string $tableName): void { }
     public function parseColumnType(array $colType): array { return []; }
+    public function quoteIdentifier(string $identifier): string { return '`' . str_replace('`', '``', $identifier) . '`'; }
     public function restoreParameters(): string { return ''; }
     public function setupTransaction(): string { return ''; }
     public function showColumns(string $tableName): string { return ''; }

--- a/tests/TableDataDumperTest.php
+++ b/tests/TableDataDumperTest.php
@@ -153,6 +153,45 @@ class TableDataDumperTest extends TestCase
         $this->assertStringContainsString('(3,NULL)', $output);
     }
 
+    public function testTableAndColumnNamesWithBackticksAreEscaped(): void
+    {
+        // SQLite supports MySQL-style backtick quoting including doubling
+        $this->pdo->exec('CREATE TABLE `weird``name` (id INTEGER, `col``umn` TEXT)');
+        $this->pdo->exec("INSERT INTO `weird``name` VALUES (1, 'x')");
+
+        $dumpSettings = new DumpSettings(['complete-insert' => true]);
+        $writer = new DumpWriter($dumpSettings);
+        $writer->initialize($this->outputFile);
+
+        $columnTypes = [
+            'id' => ['is_numeric' => true, 'is_blob' => false, 'type' => 'int', 'type_sql' => 'int', 'is_virtual' => false],
+            'col`umn' => ['is_numeric' => false, 'is_blob' => false, 'type' => 'text', 'type_sql' => 'text', 'is_virtual' => false],
+        ];
+
+        $dumper = new TableDataDumper(
+            conn: $this->pdo,
+            settings: $dumpSettings,
+            db: new FakeTypeAdapter($this->pdo, $dumpSettings),
+            writer: $writer,
+            getColumnTypes: fn(string $table): array => $columnTypes,
+            getTableWhere: fn(string $table): false => false,
+            getTableLimit: fn(string $table): false => false,
+        );
+
+        $dumper->dump('weird`name');
+        $writer->close();
+
+        $output = file_get_contents($this->outputFile);
+
+        $this->assertStringContainsString(
+            "INSERT INTO `weird``name` (`id`, `col``umn`) VALUES (1,'x');",
+            $output
+        );
+        // Comment headers quote identifiers too, like native mysqldump
+        $this->assertStringContainsString('-- Dumping data for table `weird``name`', $output);
+        $this->assertStringContainsString('-- Dumped table `weird``name` with 1 row(s)', $output);
+    }
+
     public function testInfoHookReportsRowCount(): void
     {
         $payloads = [];

--- a/tests/TypeAdapterMysqlTest.php
+++ b/tests/TypeAdapterMysqlTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Druidfi\Mysqldump\Tests;
+
+use Druidfi\Mysqldump\DumpSettings;
+use Druidfi\Mysqldump\TypeAdapter\TypeAdapterMysql;
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TypeAdapterMysql::class)]
+class TypeAdapterMysqlTest extends TestCase
+{
+    private function createAdapter(): TypeAdapterMysql
+    {
+        // ERRMODE_SILENT: the constructor's MySQL init commands (SET NAMES ...)
+        // are not valid SQLite and must not abort the test.
+        $pdo = new PDO('sqlite::memory:', options: [PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]);
+
+        return new TypeAdapterMysql($pdo, new DumpSettings([]));
+    }
+
+    public function testQuoteIdentifierWrapsInBackticks(): void
+    {
+        $adapter = $this->createAdapter();
+
+        $this->assertSame('`users`', $adapter->quoteIdentifier('users'));
+    }
+
+    public function testQuoteIdentifierEscapesEmbeddedBackticks(): void
+    {
+        $adapter = $this->createAdapter();
+
+        $this->assertSame('`weird``name`', $adapter->quoteIdentifier('weird`name'));
+        $this->assertSame('``` `', $adapter->quoteIdentifier('` '));
+    }
+
+    public function testShowCreateStatementsQuoteTheName(): void
+    {
+        $adapter = $this->createAdapter();
+
+        $this->assertSame('SHOW CREATE TABLE `weird``name`', $adapter->showCreateTable('weird`name'));
+        $this->assertSame('SHOW CREATE VIEW `v`', $adapter->showCreateView('v'));
+    }
+
+    public function testOutputStatementsQuoteTheName(): void
+    {
+        $adapter = $this->createAdapter();
+
+        $this->assertSame(
+            'DROP TABLE IF EXISTS `weird``name`;' . PHP_EOL,
+            $adapter->dropTable('weird`name')
+        );
+        $this->assertSame(
+            'LOCK TABLES `weird``name` WRITE;' . PHP_EOL,
+            $adapter->startAddLockTable('weird`name')
+        );
+        $this->assertSame(
+            '/*!40000 ALTER TABLE `weird``name` DISABLE KEYS */;' . PHP_EOL,
+            $adapter->startAddDisableKeys('weird`name')
+        );
+    }
+
+    public function testShowTablesQuotesDatabaseNameAsStringLiteral(): void
+    {
+        $adapter = $this->createAdapter();
+
+        $this->assertStringContainsString("TABLE_SCHEMA='test'", $adapter->showTables('test'));
+        // A quote in the database name must not break out of the string literal
+        $this->assertStringContainsString("TABLE_SCHEMA='te''st'", $adapter->showTables("te'st"));
+    }
+}


### PR DESCRIPTION
## What

Completes task 18 of `docs/tasks.md` (harden identifier and input handling). A table, view, column, trigger, routine or event name containing a backtick previously broke both the internal queries (`SELECT`, `SHOW CREATE`, `LOCK TABLES`) and the generated dump statements.

- **New `TypeAdapterInterface::quoteIdentifier()`** — the MySQL implementation wraps names in backticks and doubles embedded backticks, matching native mysqldump.
- **Applied at every identifier interpolation site**: the data `SELECT` + `INSERT`/`REPLACE` statements and column lists in `TableDataDumper`; all `SHOW CREATE` / `DROP` / `LOCK TABLES` / `ALTER TABLE ... KEYS` / `CREATE DATABASE`/`USE` statements in `TypeAdapterMysql`; the Stand-In table DDL in `Mysqldump`.
- **INFORMATION_SCHEMA lookups**: database names there are string literals, not identifiers — they now go through `PDO::quote()` instead of raw `'%s'` interpolation.
- **Comment headers quote the names too.** Verified against native mariadb-dump, which writes the quoted form (`` `weird``name` ``) in its `-- Table structure for table ...` comments; output is byte-identical for names without backticks.
- **Raw-SQL settings documented** (second half of task 18): README warning that the `where` setting, `setTableWheres()` and `setTableLimits()` are inserted as raw SQL by design and must never contain untrusted input; same note in the setter docblocks and the `ConfigOption::WHERE` description.

`TypeAdapterInterface` gaining a method is a breaking change for custom adapters — listed in the README 2.x → 3.x upgrade section.

## Why

Task 18: prepared statements can't bind identifiers, so a dump tool must escape them itself. Names with backticks are legal in MySQL and previously produced broken queries or a corrupt dump.

## Testing

- New `TypeAdapterMysqlTest` covering `quoteIdentifier()` edge cases, quoted SHOW CREATE/DROP/LOCK output, and string-literal quoting of database names
- New `TableDataDumperTest` case dumping a table named ``weird`name`` with column ``col`umn`` (SQLite supports MySQL-style backtick doubling), asserting the INSERT, complete-insert column list and comment headers
- End-to-end against real MySQL 8.0 in the test containers: dumped a `backtick_test` database with the same weird names; backticks correctly doubled everywhere and shared lines match native dump output
- Integration suite (byte-for-byte vs native mysqldump, 39 comparisons): PHP 8.4 × MySQL 8.0 / MySQL 8.4 / MariaDB 10.11 and PHP 8.5 × MySQL 8.0 — all pass
- `vendor/bin/phpunit` — 89 tests, 194 assertions, green; PHPStan level 6 clean; Rector dry-run clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)