### PR TITLE
ci: replace frozen Bitnami database images with official ones

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,30 +26,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    services:
-      db:
-        image: ${{ matrix.database_image }}
-        env:
-          # The MySQL docker container requires these environment variables to be set
-          # so we can create and migrate the test database.
-          # See: https://hub.docker.com/_/mysql
-          MARIADB_ROOT_PASSWORD: example
-          MYSQL_ROOT_PASSWORD: example
-          MYSQL_DATABASE: example
-          MYSQL_USER: example
-          MYSQL_PASSWORD: example
-          MYSQL_AUTHENTICATION_PLUGIN: ${{ matrix.auth_plugin }}
-          # MySQL 8.4 disables mysql_native_password by default, but the
-          # MariaDB client on the runner cannot use caching_sha2_password
-          # without TLS, so the plugin is re-enabled via server flag.
-          MYSQL_EXTRA_FLAGS: ${{ matrix.mysql_extra_flags }}
-        ports:
-          # Opens port 3306 on service container and host
-          # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
-          - 3306:3306
-          # Before continuing, verify the mysql container is reachable from the ubuntu host
-        options: --name db --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
     strategy:
       fail-fast: false
       matrix:
@@ -58,39 +34,37 @@ jobs:
           # MySQL 8.0
           - os: ubuntu-24.04
             database: mysql
-            database_image: bitnamilegacy/mysql:8.0.40
+            database_image: mysql:8.0
             php-version: 8.4
-            auth_plugin: mysql_native_password
           - os: ubuntu-24.04
             database: mysql
-            database_image: bitnamilegacy/mysql:8.0.40
+            database_image: mysql:8.0
             php-version: 8.5
-            auth_plugin: mysql_native_password
 
-          # MySQL 8.4 LTS (no auth_plugin: the default_authentication_plugin
-          # server option was removed in 8.4)
+          # MySQL 8.4 LTS: mysql_native_password is disabled by default, but
+          # the test user needs it (the clients used in tests cannot use
+          # caching_sha2_password without TLS), so the plugin is re-enabled
+          # via server flag — same as compose.yaml.
           - os: ubuntu-24.04
             database: mysql
-            database_image: bitnamilegacy/mysql:8.4.5
+            database_image: mysql:8.4
             php-version: 8.4
-            mysql_extra_flags: --mysql-native-password=ON
+            database_flags: --mysql-native-password=ON
           - os: ubuntu-24.04
             database: mysql
-            database_image: bitnamilegacy/mysql:8.4.5
+            database_image: mysql:8.4
             php-version: 8.5
-            mysql_extra_flags: --mysql-native-password=ON
+            database_flags: --mysql-native-password=ON
 
           # MariaDB 10.11 LTS
           - os: ubuntu-22.04
             database: mariadb
-            database_image: bitnamilegacy/mariadb:10.11.9
+            database_image: mariadb:10.11
             php-version: 8.4
-            auth_plugin: mysql_native_password
           - os: ubuntu-22.04
             database: mariadb
-            database_image: bitnamilegacy/mariadb:10.11.9
+            database_image: mariadb:10.11
             php-version: 8.5
-            auth_plugin: mysql_native_password
 
     steps:
 
@@ -99,6 +73,22 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Start database container
+        # Same setup as compose.yaml: official image, the repo init script is
+        # run by the image entrypoint, and server flags are passed as command
+        # arguments. A `docker run` step is used instead of a GitHub `services:`
+        # block because services start before checkout (no repo files to mount)
+        # and cannot pass command arguments — the two limitations that
+        # previously forced the Bitnami images with their custom env vars.
+        # The database boots in the background while the PHP steps run.
+        run: |
+          docker run --detach --name db \
+            --publish 3306:3306 \
+            --env MYSQL_ROOT_PASSWORD=example \
+            --env MARIADB_ROOT_PASSWORD=example \
+            --volume "$PWD/docker-entrypoint-initdb.d/${{ matrix.database }}-init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro" \
+            ${{ matrix.database_image }} ${{ matrix.database_flags }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -120,11 +110,21 @@ jobs:
       - name: Run PHPunit tests
         run: vendor/bin/phpunit
 
-      - name: Create user and databases for testing
-        # Run inside the service container over the local socket: on
-        # MySQL 8.4 the root user uses caching_sha2_password, which the
-        # runner's MariaDB client cannot authenticate with over plain TCP.
-        run: cat docker-entrypoint-initdb.d/${{ matrix.database }}-init.sql | docker exec -i -e MYSQL_PWD=example db mysql -uroot
+      - name: Wait for database to be ready
+        # -h127.0.0.1 forces TCP inside the container: the entrypoint's
+        # temporary init-phase server only listens on the unix socket, so this
+        # only succeeds once the final server is up and the init script
+        # (which creates the example user and test databases) has run.
+        run: |
+          for i in $(seq 1 60); do
+            if docker exec db mysql -h127.0.0.1 -uexample -pexample -e "SELECT 1" >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Database did not become ready in time" >&2
+          docker logs db >&2
+          exit 1
 
       - name: Run test script
         run: |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -139,7 +139,10 @@ codebase; items that are done are kept checked for history.
     - [x] Test with different PHP versions
     - [ ] Broaden dump-settings coverage in `tests/scripts/test.sh` (e.g. compression methods,
           `no-data` patterns, `skip-definer`; `complete-insert` is already covered)
-    - [ ] Add MariaDB 11.x LTS to the matrix when supported by the test images
+    - [ ] Add MariaDB 11.x LTS to the matrix — unblocked since CI switched from the frozen
+          `bitnamilegacy/*` images to official ones (`mariadb:11.8` LTS exists); needs a trial
+          run first to check for output drift in the filtered diffs (e.g. the mariadb-dump
+          sandbox-mode header line)
 
 16. [ ] Add performance testing:
     - [ ] Benchmark dump operations against a large fixture database


### PR DESCRIPTION
## What

Switches the CI test matrix from `bitnamilegacy/mysql:8.0.40` / `bitnamilegacy/mysql:8.4.5` / `bitnamilegacy/mariadb:10.11.9` to the official `mysql:8.0` / `mysql:8.4` / `mariadb:10.11` images — the same ones `compose.yaml` has used locally all along.

- The `services:` block is replaced with a `docker run` step that mirrors compose.yaml exactly: official image, the repo's `docker-entrypoint-initdb.d/*-init.sql` mounted and executed by the image entrypoint, and `--mysql-native-password=ON` passed as a command argument for MySQL 8.4.
- The separate "create user and databases" step is gone — the entrypoint runs the init script, as it does locally.
- Readiness is gated by an explicit wait step before `test.sh`: a TCP connection as the `example` user from inside the container only succeeds once the final server is up and initialized (the entrypoint's temporary init-phase server is socket-only).
- The database boots in the background while checkout/PHP/composer/QA steps run, so job duration should be unchanged.

## Why

The `bitnamilegacy` namespace is frozen — Bitnami stopped publishing free updates in 2025 — so CI was pinned to database images that will never get another patch. CI only used Bitnami because GitHub's `services:` block can't mount repo files or pass server command args, which Bitnami papered over with custom env vars (`MYSQL_AUTHENTICATION_PLUGIN`, `MYSQL_EXTRA_FLAGS`). A `docker run` step has neither limitation.

This also achieves true local/CI parity (same images, same init mechanism, same flags) and unblocks adding MariaDB 11.x LTS to the matrix (task 15) — official `mariadb:11.8` exists, `bitnamilegacy` stopped at 10.11.

## Testing

- All three `docker run` invocations verified locally against the official images: entrypoint init creates the `example` user with `mysql_native_password` and all test databases; the mariadb image still ships the `mysql`/`mysqldump` compatibility symlinks the test step's alias relies on.
- Local compose setup is untouched (already official) and its integration matrix passed on all three databases earlier today.
- The 6-job matrix run on this PR is the end-to-end validation of the runner-side wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)