### PR TITLE
feat(ci): add MariaDB 11.8 LTS to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,17 @@ jobs:
             database_image: mariadb:10.11
             php-version: 8.5
 
+          # MariaDB 11.8 LTS (the image no longer ships the mysql/mysqldump
+          # compatibility symlinks — container binaries are mariadb/mariadb-dump)
+          - os: ubuntu-22.04
+            database: mariadb
+            database_image: mariadb:11.8
+            php-version: 8.4
+          - os: ubuntu-22.04
+            database: mariadb
+            database_image: mariadb:11.8
+            php-version: 8.5
+
     steps:
 
       - name: Checkout code
@@ -115,9 +126,12 @@ jobs:
         # temporary init-phase server only listens on the unix socket, so this
         # only succeeds once the final server is up and the init script
         # (which creates the example user and test databases) has run.
+        # MariaDB 11+ images no longer ship the `mysql` compatibility symlink.
         run: |
+          CLIENT=mysql
+          if [ "${{ matrix.database }}" = "mariadb" ]; then CLIENT=mariadb; fi
           for i in $(seq 1 60); do
-            if docker exec db mysql -h127.0.0.1 -uexample -pexample -e "SELECT 1" >/dev/null 2>&1; then
+            if docker exec db "$CLIENT" -h127.0.0.1 -uexample -pexample -e "SELECT 1" >/dev/null 2>&1; then
               exit 0
             fi
             sleep 2
@@ -127,8 +141,9 @@ jobs:
           exit 1
 
       - name: Run test script
+        # test.sh compares against the runner's own mysqldump binary. (An
+        # earlier `alias mysqldump='docker exec db mysqldump'` here never
+        # reached test.sh — aliases do not propagate to child processes.)
         run: |
-          shopt -s expand_aliases
-          alias mysqldump='docker exec db mysqldump'
           mysqldump --version
           cd tests/scripts && ./test.sh 127.0.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ docs/
 
 # Root-level Docker test setup
 Dockerfile                     # PHP test container (PHP_SHORT_VERSION build arg)
-compose.yaml                   # Services: mysql, mysql84, mariadb, php84, php85
+compose.yaml                   # Services: mysql, mysql84, mariadb, mariadb11, php84, php85
 config/skip-ssl.cnf            # MySQL client config for test containers
 docker-entrypoint-initdb.d/    # DB init scripts (mysql-init.sql, mariadb-init.sql)
 .env.mysql                     # Shared DB credentials for compose services
@@ -106,7 +106,7 @@ cd tests/scripts && ./test.sh 127.0.0.1
 
 # Docker-based testing
 docker compose up mysql php84    # or php85; mysql84 for MySQL 8.4 LTS
-docker compose up mariadb php84  # same, against MariaDB
+docker compose up mariadb php84  # same, against MariaDB (mariadb11 for 11.8 LTS)
 ```
 
 ## Key Coding Conventions
@@ -166,14 +166,14 @@ Druidfi\Mysqldump\
 ### Integration Tests
 - Compare mysqldump-php output against native mysqldump
 - Tests must produce identical output to pass
-- Run against MySQL 8.0 and MariaDB 10.11
+- Run against MySQL 8.0/8.4 and MariaDB 10.11/11.8
 - Test fixtures in `tests/scripts/test*.src.sql`
 
 ### CI Matrix
 Tests run on:
 - PHP: 8.4, 8.5
-- Databases: MySQL 8.0, MySQL 8.4 LTS, MariaDB 10.11
-- Total: 6 combinations
+- Databases: MySQL 8.0, MySQL 8.4 LTS, MariaDB 10.11 LTS, MariaDB 11.8 LTS
+- Total: 8 combinations
 
 The `2.x` branch keeps the wider PHP 8.1–8.5 matrix (10 combinations).
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ docker compose exec -w /app/tests/scripts php84 ./test.sh mysql84
 docker compose exec -w /app/tests/scripts php85 ./test.sh mysql84
 docker compose exec -w /app/tests/scripts php84 ./test.sh mariadb
 docker compose exec -w /app/tests/scripts php85 ./test.sh mariadb
+docker compose exec -w /app/tests/scripts php84 ./test.sh mariadb11
+docker compose exec -w /app/tests/scripts php85 ./test.sh mariadb11
 ```
 
 ## Credits

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,14 @@ services:
     volumes:
       - ./docker-entrypoint-initdb.d/mariadb-init.sql:/docker-entrypoint-initdb.d/00-init.sql
 
+  mariadb11:
+    container_name: mysqldump-php-mariadb-11
+    image: mariadb:11.8
+    env_file:
+      - .env.mysql
+    volumes:
+      - ./docker-entrypoint-initdb.d/mariadb-init.sql:/docker-entrypoint-initdb.d/00-init.sql
+
   php84:
     container_name: mysqldump-php-84
     build:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -139,10 +139,10 @@ codebase; items that are done are kept checked for history.
     - [x] Test with different PHP versions
     - [ ] Broaden dump-settings coverage in `tests/scripts/test.sh` (e.g. compression methods,
           `no-data` patterns, `skip-definer`; `complete-insert` is already covered)
-    - [ ] Add MariaDB 11.x LTS to the matrix — unblocked since CI switched from the frozen
-          `bitnamilegacy/*` images to official ones (`mariadb:11.8` LTS exists); needs a trial
-          run first to check for output drift in the filtered diffs (e.g. the mariadb-dump
-          sandbox-mode header line)
+    - [x] Add MariaDB 11.x LTS to the matrix — `mariadb:11.8` added to compose.yaml
+          (`mariadb11` service) and to CI (8 combinations total); the filtered diffs proved
+          immune to the 11.x output drift, but the image drops the `mysql`/`mysqldump`
+          compatibility symlinks, so the CI readiness gate picks the client binary per database
 
 16. [ ] Add performance testing:
     - [ ] Benchmark dump operations against a large fixture database


### PR DESCRIPTION
## What

Stacked on #97 (official images). Completes the last open item of task 15:

- New `mariadb11` service in `compose.yaml` (official `mariadb:11.8` LTS, same init script as the 10.11 service).
- Two new CI jobs (`mariadb:11.8` × PHP 8.4/8.5), bringing the matrix to 8 combinations.
- The CI readiness gate picks the client binary per database — the `mariadb:11.8` image no longer ships the `mysql`/`mysqldump` compatibility symlinks.
- Removed the test step's `alias mysqldump='docker exec db mysqldump'`, which would have hard-failed against 11.8. It was also dead code: aliases don't propagate to child processes, so `test.sh` has always compared against the runner's own mysqldump binary — the alias only mislabelled the version printout.
- Docs updated (CLAUDE.md matrix/services, README test commands, task 15 fully checked off).

## Why

MariaDB 11.8 is the current LTS; the matrix was stuck at 10.11 while the CI images were pinned to the frozen `bitnamilegacy` namespace. #97 removed that blocker.

## Testing

- Full integration suite (39 byte-for-byte comparisons) run locally against `mariadb:11.8` on both PHP 8.4 and PHP 8.5 — all pass with **no filter changes needed**; the known 11.x dump-output drift (sandbox-mode header) never reaches the filtered diffs.
- Workflow YAML validated; the 8-job matrix run on this PR is the end-to-end check of the readiness-gate binary selection.

⚠️ Merge #97 first — this PR is based on its branch and will retarget to `main` automatically when #97 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)