### PR TITLE
docs: add security policy and credential practices documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,27 @@ Use **SHOW GRANTS FOR user@host;** to know what privileges user has. See the fol
 - [Which are the minimum privileges required to get a backup of a MySQL database schema?](https://dba.stackexchange.com/questions/55546/which-are-the-minimum-privileges-required-to-get-a-backup-of-a-mysql-database-sc/55572#55572)
 - [PROCESS privilege from MySQL 5.7.31 and MySQL 8.0.21 in July 2020](https://anothercoffee.net/how-to-fix-the-mysqldump-access-denied-process-privilege-error/)
 
+## Security considerations
+
+The library never stores credentials — they are passed to the constructor and used only to open
+the PDO connection. Keeping them safe is the calling application's responsibility. Do not hardcode
+credentials in code or commit them to version control; read them from environment variables or a
+secret manager instead:
+
+```php
+$dump = new \Druidfi\Mysqldump\Mysqldump(
+    sprintf('mysql:host=%s;dbname=%s', getenv('DB_HOST'), getenv('DB_NAME')),
+    getenv('DB_USER'),
+    getenv('DB_PASSWORD')
+);
+```
+
+Remember that the `where`, `setTableWheres()` and `setTableLimits()` values are raw SQL and must
+not be built from untrusted input — see the warning under
+[Table specific export conditions](#table-specific-export-conditions).
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).
+
 ## Tests
 
 The testing script creates and populates a database using all possible datatypes. Then it exports it using both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Branch | Supported          |
+|---------|--------|--------------------|
+| 3.x     | `main` | ✅ (in development) |
+| 2.x     | `2.x`  | ✅ (maintenance)    |
+| 1.x     | `1.x`  | ❌                  |
+
+Security fixes land on `main` first and are backported to `2.x` when relevant.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security problems. Instead, use GitHub's private
+vulnerability reporting to contact the maintainers:
+
+- [Report a vulnerability](https://github.com/druidfi/mysqldump-php/security/advisories/new)
+  (repository **Security** tab → *Report a vulnerability*)
+
+Include in your report:
+
+- The affected version(s) and PHP/database versions used
+- Steps to reproduce, ideally with a minimal code example
+- The impact you believe the vulnerability has
+
+You will get a response as soon as possible, typically within a few days. Once a fix is
+released, the advisory is published and you will be credited unless you prefer otherwise.
+
+## Scope
+
+The `where` dump setting, `setTableWheres()` and `setTableLimits()` values are inserted into
+the dump's `SELECT` statements as **raw SQL by design** — that is what makes arbitrary export
+conditions possible. They are documented as unsafe for untrusted input (see the warning in the
+[README](README.md#table-specific-export-conditions)). Reports that only demonstrate SQL
+injection through these values under the caller's control are not considered vulnerabilities
+in this library.
+
+Credential storage and rotation are the responsibility of the calling application; see the
+[Security considerations](README.md#security-considerations) section in the README.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -170,10 +170,13 @@ codebase; items that are done are kept checked for history.
     - [x] Document that `where`, `tableWheres` and `tableLimits` are raw SQL by design and must not
           contain untrusted input (README warning + setter docblocks + `ConfigOption` description)
 
-19. [ ] Improve security posture of the project:
-    - [ ] Add a SECURITY.md with a vulnerability reporting policy
-    - [ ] Document secure credential practices (env vars, secret managers) in the README
-          — actual credential storage/rotation is the caller's responsibility, not the library's
+19. [x] Improve security posture of the project:
+    - [x] Add a SECURITY.md with a vulnerability reporting policy — supported versions,
+          GitHub private vulnerability reporting as the channel, and a scope note that the
+          raw-SQL settings (`where`/`tableWheres`/`tableLimits`) are by design
+    - [x] Document secure credential practices (env vars, secret managers) in the README
+          ("Security considerations" section with a `getenv()` example) — actual credential
+          storage/rotation stays the caller's responsibility, not the library's
 
 ## Feature Enhancements
 


### PR DESCRIPTION
## Summary

Closes roadmap task 19 (*Improve security posture of the project*) in `docs/tasks.md`:

- **New `SECURITY.md`** — supported versions table (3.x/2.x supported, 1.x not), vulnerability reporting via [GitHub private vulnerability reporting](https://github.com/druidfi/mysqldump-php/security/advisories/new) (already enabled on the repo), and a scope note that the raw-SQL settings (`where`/`tableWheres`/`tableLimits`) are unsafe for untrusted input **by design**, pre-empting invalid reports.
- **README "Security considerations" section** — credentials are the caller's responsibility; don't hardcode them, read from env vars or a secret manager (`getenv()` example). Cross-links the existing raw-SQL warning and SECURITY.md.
- **`docs/tasks.md`** — task 19 checked off with inline notes.

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)