### PR TITLE
docs: document dumping to stream wrappers (cloud storage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Out of the box, `mysqldump-php` supports backing up table structures, the data i
 - supports virtual columns from MySQL 5.7
 - does insert-ignore, like a REPLACE but ignoring errors if a duplicate key exists
 - modifying data from database on-the-fly when dumping, using hooks
-- can save directly to Google Cloud storage over a compressed stream wrapper (GZIPSTREAM)
+- can save directly to cloud storage (Google Cloud Storage, Amazon S3, ...) over
+  [PHP stream wrappers](#dumping-to-cloud-storage-and-other-streams)
 
 ## Requirements
 
@@ -220,6 +221,29 @@ $dumper->setTableLimits([
     'users' => [20, 10], // MySQL query equivalent "... LIMIT 20, 10", i.e. 10 rows starting from offset 20
 ]);
 ```
+## Dumping to cloud storage and other streams
+
+The filename given to `start()` is opened with PHP's `fopen()`, so any registered
+[stream wrapper](https://www.php.net/manual/en/wrappers.php) works as a dump target: built-in ones
+like `php://stdout` or `ftp://`, and cloud storage wrappers registered by the respective SDKs —
+`gs://` by [google/cloud-storage](https://github.com/googleapis/google-cloud-php-storage), `s3://` by
+[aws/aws-sdk-php](https://github.com/aws/aws-sdk-php), or any
+[league/flysystem](https://flysystem.thephpleague.com/) adapter exposed as a wrapper. No cloud SDK
+dependencies are needed in this library:
+
+```php
+$storage = new Google\Cloud\Storage\StorageClient(['projectId' => 'my-project']);
+$storage->registerStreamWrapper();
+
+$dump = new \Druidfi\Mysqldump\Mysqldump($dsn, $user, $pass, ['compress' => 'Gzipstream']);
+$dump->start('gs://my-bucket/backup.sql.gz');
+```
+
+> [!NOTE]
+> The `Gzip` and `Bzip2` compression methods use `gzopen()`/`bzopen()`, which only work on local
+> files. When dumping to a stream wrapper, use `Gzipstream` (identical gzip output written through
+> `fopen()`), `Zstd`, `Lz4` or `None`.
+
 ## Dump Settings
 
 Dump settings can be changed from default values with the 4th argument of the Mysqldump constructor.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -119,12 +119,15 @@ codebase; items that are done are kept checked for history.
     - [x] Remove stale PHPDoc — the `getDatabaseStructure*` docblocks claiming to fill a
           non-existent `$this->tables` array went away with the methods themselves (task 1)
 
-13. [ ] Improve user documentation (README already covers install, hooks, settings, privileges):
+13. [x] Improve user documentation (README already covers install, hooks, settings, privileges):
     - [x] Document 2.x → 3.x upgrade / breaking changes (README "Upgrading from 2.x to 3.x")
     - [x] Replace references to the ifsnop wiki with own examples
     - [x] Document compression options incl. optional ext-zstd / ext-lz4 requirements
-    - [ ] Document dumping to stream wrappers (gs://, s3:// via league/flysystem etc.)
-          instead of adding cloud SDK dependencies to the library
+    - [x] Document dumping to stream wrappers (gs://, s3:// via league/flysystem etc.)
+          instead of adding cloud SDK dependencies to the library — README "Dumping to cloud
+          storage and other streams" section: `start()` opens the target with `fopen()`, so any
+          registered wrapper works; notes that `Gzip`/`Bzip2` are local-only and `Gzipstream`
+          is the wrapper-safe gzip
 
 ## Testing Improvements
 


### PR DESCRIPTION
## Summary

Closes roadmap task 13.4 — the last open item of task 13 (*Improve user documentation*) in `docs/tasks.md`:

- **README "Dumping to cloud storage and other streams" section** — explains that the filename given to `start()` goes to PHP's `fopen()`, so any registered stream wrapper works as a dump target (`gs://` via google/cloud-storage, `s3://` via aws-sdk-php, league/flysystem adapters), with a GCS code example. No cloud SDK dependencies needed in the library.
- **The gotcha, now documented**: `Gzip`/`Bzip2` use `gzopen()`/`bzopen()` which only work on local files — `Gzipstream` is the wrapper-safe gzip (identical output via `fopen()` + `deflate_add()`), and `Zstd`/`Lz4`/`None` are wrapper-safe too.
- **Feature list bullet updated** — the old "can save directly to Google Cloud storage (GZIPSTREAM)" claim now links to the new section and mentions S3 as well.
- **`docs/tasks.md`** — task 13 fully checked off with inline notes.

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)