### PR TITLE
perf: free column type maps once each table or view is dumped

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ from 2.x. The following changes may require action:
 - **`compress-level` is validated per method.** Levels up to the method maximum are accepted
   (Gzip 1-9, Lz4 1-12, Zstd 1-22) where 2.x rejected everything above 9, and a level above the
   method maximum now throws with a method-specific message.
+- **The protected `Mysqldump::tableColumnTypes()` accessor was removed.** Column type maps are
+  now freed as soon as each table or view has been dumped, so memory no longer grows with the
+  number of tables; the accessor had nothing meaningful to return anymore.
 - **Exceptions are now typed.** The library throws subclasses of
   `Druidfi\Mysqldump\Exception\MysqldumpException` instead of bare `Exception`. No action is
   needed — the base class extends `Exception`, so existing `catch (\Exception $e)` blocks keep

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -153,13 +153,16 @@ codebase; items that are done are kept checked for history.
 
 ## Performance Improvements
 
-17. [ ] Optimize memory usage:
+17. [x] Optimize memory usage:
     - [x] Review and optimize large data structures
     - [x] Use generators for large result sets
     - [x] `iterate*()` generator buffering reviewed and kept as deliberate: only object *names*
           are buffered (tiny), and the cursor must be closed before consumers run their own
           queries per object — documented in `iterateObjectNames()`
-    - [ ] Review `$tableColumnTypes` growth on databases with many tables/columns
+    - [x] Review `$tableColumnTypes` growth on databases with many tables/columns — entries are
+          strictly populate-then-consume (table structure → data dump; view → Stand-In table),
+          so each entry is now freed right after its table/view is dumped and memory stays flat;
+          the unused protected `tableColumnTypes()` accessor was removed (README upgrade note)
 
 ## Security Improvements
 

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -209,6 +209,9 @@ class Mysqldump
                 if (!$no_data && !$this->matches($table, $this->settings->getNoData())) {
                     $dataDumper->dump($table);
                 }
+                // Column types are only needed between structure and data dump of this
+                // table; free them so the map does not grow with the number of tables.
+                unset($this->tableColumnTypes[$table]);
             },
             getExcludedTables: fn(): array => $this->settings->getExcludedTables(),
             getNoData: fn(): array => $this->settings->getNoData()
@@ -237,6 +240,8 @@ class Mysqldump
                 if ($this->matches($name, $this->settings->getExcludedTables())) { return; }
                 $this->tableColumnTypes[$name] = $this->getTableColumnTypes($name);
                 $this->getViewStructureTable($name);
+                // Only the Stand-In table above needs the view's column types.
+                unset($this->tableColumnTypes[$name]);
             },
             getViewStructureView: function (string $name): void {
                 if ($this->settings->isEnabled('no-create-info')) { return; }
@@ -482,16 +487,6 @@ class Mysqldump
         $columns->closeCursor();
 
         return $columnTypes;
-    }
-
-    /**
-     * Get table column types.
-     *
-     * @return array<string, array<string, array<string, mixed>>>
-     */
-    protected function tableColumnTypes(): array
-    {
-        return $this->tableColumnTypes;
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes roadmap task 17.4 — the last open item of task 17 (*Optimize memory usage*) in `docs/tasks.md`:

- **`$tableColumnTypes` no longer grows with the schema.** Entries are strictly populate-then-consume: a table's entry is used only between its structure dump and its data dump (`getTableStructure()` → `TableDataDumper`), and a view's entry only for its Stand-In table. Each entry is now `unset` right after its table/view is dumped, so peak memory holds one table's column map instead of the whole schema's.
- **Removed the protected `tableColumnTypes()` accessor** — it had zero callers in src/ and tests/, and with the map now transient it had nothing meaningful to return. Documented in the README "Upgrading from 2.x to 3.x" section since it existed in 2.x.

## Measured memory impact

Synthetic schema of N tables × 20 columns each (1 row per table), dumped from the php84 container against the MySQL 8.0 container, reading `memory_get_peak_usage()` after `start()`:

| Tables | main (peak) | this PR (peak) |
|--------|-------------|----------------|
| 500    | 6.76 MB     | 1.78 MB        |
| 1000   | 11.80 MB    | 1.78 MB        |

On `main` peak memory grows linearly with the schema (roughly 0.5 KB retained per column for the whole run); with this PR it stays flat regardless of table count, since only the current table's column map is held.

## Verification

- PHPUnit in the php84 container: 89 tests, all green
- PHPStan level 6 clean (php84 container)
- Rector dry-run clean (php84 container)
- Integration tests in Docker (php84 + MySQL 8.0): **all 39 diff tests pass** — output remains byte-for-byte identical to native mysqldump, including the view/Stand-In tests (test008/test010) that exercise the changed path

🤖 Generated with [Claude Code](https://claude.com/claude-code)