### PR TITLE
test: broaden dump-settings coverage in integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /composer.phar
 /tests/scripts/output/*.checksum
 /tests/scripts/output/*.sql
+/tests/scripts/output/*.sql.gz
 /vendor/
 /.phpunit.result.cache
 /.phpunit.cache/

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -136,12 +136,16 @@ codebase; items that are done are kept checked for history.
     - [x] Add tests for edge cases
     - [x] Implement proper mocking for dependencies
 
-15. [ ] Extend integration testing (CI already runs PHP 8.4/8.5 × MySQL 8.0/8.4/MariaDB 10.11 and
+15. [x] Extend integration testing (CI already runs PHP 8.4/8.5 × MySQL 8.0/8.4/MariaDB 10.11 and
         compares output against native mysqldump):
     - [x] Test with different database versions
     - [x] Test with different PHP versions
-    - [ ] Broaden dump-settings coverage in `tests/scripts/test.sh` (e.g. compression methods,
-          `no-data` patterns, `skip-definer`; `complete-insert` is already covered)
+    - [x] Broaden dump-settings coverage in `tests/scripts/test.sh` (e.g. compression methods,
+          `no-data` patterns, `skip-definer`; `complete-insert` is already covered) — test017
+          proves Gzip/Gzipstream dumps decompress byte-identical to an uncompressed reference
+          (Bzip2/Zstd/Lz4 need optional extensions and stay unit-test-covered); test018 covers
+          `no-data` with an exact name + regex pattern (both `matches()` branches);
+          `skip-definer` was already covered by the test012 no-definer dump
     - [x] Add MariaDB 11.x LTS to the matrix — `mariadb:11.8` added to compose.yaml
           (`mariadb11` service) and to CI (8 combinations total); the filtered diffs proved
           immune to the 11.x output drift, but the image drops the `mysql`/`mysqldump`

--- a/tests/scripts/test.php
+++ b/tests/scripts/test.php
@@ -246,6 +246,59 @@ try {
 
     $dump->start("output/mysqldump-php_test016.sql");
 
+    // test017: compression methods — the decompressed output must be byte-identical to an
+    // uncompressed dump made with the same settings. skip-dump-date makes the dumps
+    // reproducible across runs. Gzip and Gzipstream only: ext-zlib is always available,
+    // while Bzip2/Zstd/Lz4 need optional extensions and are covered by unit tests.
+    $compressionSettings = [
+        'extended-insert' => false,
+        'hex-blob' => true,
+        'skip-dump-date' => true,
+    ];
+
+    print "Create dump with PHP: mysql-php_test017.sql (compression reference)" . PHP_EOL;
+
+    $dump = new Mysqldump("mysql:host=$host;dbname=test001", $user, $pass, $compressionSettings);
+    $dump->start("output/mysqldump-php_test017.sql");
+
+    print "Create dump with PHP: mysql-php_test017_gzip.sql.gz (Gzip)" . PHP_EOL;
+
+    $dump = new Mysqldump(
+        "mysql:host=$host;dbname=test001",
+        $user,
+        $pass,
+        ['compress' => CompressManagerFactory::GZIP] + $compressionSettings
+    );
+
+    $dump->start("output/mysqldump-php_test017_gzip.sql.gz");
+
+    print "Create dump with PHP: mysql-php_test017_gzipstream.sql.gz (Gzipstream)" . PHP_EOL;
+
+    $dump = new Mysqldump(
+        "mysql:host=$host;dbname=test001",
+        $user,
+        $pass,
+        ['compress' => CompressManagerFactory::GZIPSTREAM] + $compressionSettings
+    );
+
+    $dump->start("output/mysqldump-php_test017_gzipstream.sql.gz");
+
+    print "Create dump with PHP: mysql-php_test018.sql (no-data patterns)" . PHP_EOL;
+
+    // Exact table name and regex pattern, covering both branches of matches()
+    $dump = new Mysqldump(
+        "mysql:host=$host;dbname=test001",
+        $user,
+        $pass,
+        [
+            'no-data' => ['test015', '/^test2/'],
+            'extended-insert' => false,
+            'hex-blob' => true,
+        ]
+    );
+
+    $dump->start("output/mysqldump-php_test018.sql");
+
     exit(0);
 } catch (Exception $e) {
     print "Error: " . $e->getMessage() . PHP_EOL;

--- a/tests/scripts/test.sh
+++ b/tests/scripts/test.sh
@@ -85,7 +85,7 @@ for i in 000; do
 done
 }
 
-for i in $(seq 0 40) ; do
+for i in $(seq 0 60) ; do
     ret[$i]=0
 done
 
@@ -372,6 +372,35 @@ if [[ $errCode -ne 0 ]]; then error "$test"; fi
 # test include-tables: other tables must NOT appear in the dump
 test="Test#$index include-tables: verify excluded tables absent from dump"
 ! grep -q "INSERT INTO \`test001\`\|INSERT INTO \`test002\`\|INSERT INTO \`test003\`" output/mysqldump-php_test016.sql
+errCode=$?; ret[((index++))]=$errCode
+if [[ $errCode -ne 0 ]]; then error "$test"; fi
+
+# test compression: Gzip output must decompress to exactly the uncompressed reference dump
+test="Test#$index compression: gunzip mysqldump-php_test017_gzip.sql.gz matches reference"
+gunzip -c output/mysqldump-php_test017_gzip.sql.gz > output/mysqldump-php_test017_gzip.sql \
+    && diff output/mysqldump-php_test017.sql output/mysqldump-php_test017_gzip.sql
+errCode=$?; ret[((index++))]=$errCode
+if [[ $errCode -ne 0 ]]; then error "$test"; fi
+
+# test compression: Gzipstream output must decompress to exactly the uncompressed reference dump
+test="Test#$index compression: gunzip mysqldump-php_test017_gzipstream.sql.gz matches reference"
+gunzip -c output/mysqldump-php_test017_gzipstream.sql.gz > output/mysqldump-php_test017_gzipstream.sql \
+    && diff output/mysqldump-php_test017.sql output/mysqldump-php_test017_gzipstream.sql
+errCode=$?; ret[((index++))]=$errCode
+if [[ $errCode -ne 0 ]]; then error "$test"; fi
+
+# test no-data patterns: matched tables (exact name + regex) keep structure but lose data
+test="Test#$index no-data patterns: test015/test200 structure dumped without INSERTs"
+grep -q "CREATE TABLE \`test015\`" output/mysqldump-php_test018.sql \
+    && grep -q "CREATE TABLE \`test200\`" output/mysqldump-php_test018.sql \
+    && ! grep -q "INSERT INTO \`test015\`\|INSERT INTO \`test200\`" output/mysqldump-php_test018.sql
+errCode=$?; ret[((index++))]=$errCode
+if [[ $errCode -ne 0 ]]; then error "$test"; fi
+
+# test no-data patterns: tables not matching the patterns still have their data
+test="Test#$index no-data patterns: unmatched tables keep INSERTs"
+grep -q "INSERT INTO \`test000\`" output/mysqldump-php_test018.sql \
+    && grep -q "INSERT INTO \`test027\`" output/mysqldump-php_test018.sql
 errCode=$?; ret[((index++))]=$errCode
 if [[ $errCode -ne 0 ]]; then error "$test"; fi
 


### PR DESCRIPTION
## Summary

Closes roadmap task 15.3 — the last open item of task 15 (*Extend integration testing*) in `docs/tasks.md`:

- **test017 — compression methods**: dumps test001 three times with identical settings (`skip-dump-date` makes output reproducible): uncompressed reference, `Gzip`, and `Gzipstream`. The integration script gunzips both compressed dumps and diffs them against the reference — proving the compressed output decompresses byte-identical. `Bzip2`/`Zstd`/`Lz4` need optional PHP extensions not guaranteed in the containers/runners, so they stay unit-test-covered.
- **test018 — `no-data` patterns**: dumps test001 with `'no-data' => ['test015', '/^test2/']` — an exact name and a regex, covering both branches of `matches()`. Assertions: matched tables (`test015`, `test200`) keep their `CREATE TABLE` but have no `INSERT`s; unmatched tables (`test000`, `test027`) keep their data.
- **`skip-definer`** (also named in the task) turned out to be already covered by the test012 no-definer dump and its DEFINER grep check — noted in tasks.md.
- `.gitignore` extended for the new `*.sql.gz` outputs; suite grows from 39 to 43 tests.

## Verification

Full integration suite run in the php84 container: **43/43 tests pass against both MySQL 8.0 and MariaDB 10.11**. CI will cover the remaining matrix (PHP 8.5, MySQL 8.4, MariaDB 11.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)