### PR TITLE
feat: return null from the row transform hook to skip a row

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,27 @@ $dumper->setTransformTableRowHook(function ($tableName, array $row) {
 $dumper->start('storage/work/dump.sql');
 ```
 
+## Filtering rows when exporting
+
+The same hook can drop rows entirely: return `null` instead of the row and it is left out of
+the dump. Unlike the `where`/`setTableWheres()` settings this filters in PHP, so it works for
+conditions that are hard to express in SQL or that depend on data outside the database:
+
+```php
+$dumper->setTransformTableRowHook(function ($tableName, array $row) {
+    // Exclude soft-deleted users from the dump
+    if ($tableName === 'users' && $row['deleted_at'] !== null) {
+        return null;
+    }
+
+    return $row;
+});
+```
+
+Skipped rows are not counted in the dump's row-count comments or in the info hook's `rowCount`.
+Prefer `where`/`setTableWheres()` when the condition is expressible in SQL — filtering in the
+database avoids transferring the skipped rows at all.
+
 ## Getting information about the dump
 
 You can register a callable that will be used to report on the progress of the dump

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -197,7 +197,10 @@ codebase; items that are done are kept checked for history.
 
 21. [ ] Enhance data transformation capabilities:
     - [ ] Provide ready-made anonymization helpers/recipes on top of the existing hooks
-    - [ ] Support returning `null` from hooks to skip a row entirely (row filtering)
+    - [x] Support returning `null` from hooks to skip a row entirely (row filtering) —
+          `transformTableRowHook` may now return `null` to drop the row from the dump;
+          skipped rows are excluded from row-count comments and the info hook's `rowCount`
+          (README "Filtering rows when exporting")
 
 22. [ ] Improve progress reporting (an `infoHook` with per-table row counts already exists):
     - [ ] Report total table count / overall progress, not just per-table row counts

--- a/src/Mysqldump.php
+++ b/src/Mysqldump.php
@@ -714,6 +714,9 @@ class Mysqldump
 
     /**
      * Set a callable that will be used to transform table rows.
+     *
+     * Called as function(string $tableName, array $row): ?array. Return the
+     * (possibly modified) row, or null to skip the row from the dump entirely.
      */
     public function setTransformTableRowHook(callable $callable): void
     {

--- a/src/TableDataDumper.php
+++ b/src/TableDataDumper.php
@@ -22,7 +22,7 @@ class TableDataDumper
      * @param Closure $getColumnTypes function(string $table): array<string, array<string, mixed>>
      * @param Closure $getTableWhere function(string $table): string|false
      * @param Closure $getTableLimit function(string $table): int|string|false
-     * @param Closure|null $transformTableRow function(string $table, array $row): array
+     * @param Closure|null $transformTableRow function(string $table, array $row): ?array — null skips the row
      * @param Closure|null $transformColumnValue function(string $table, string $col, mixed $value, array $row): mixed
      * @param Closure|null $info function(string $object, array $payload): void
      */
@@ -131,6 +131,14 @@ class TableDataDumper
 
         $line = '';
         foreach ($resultSet as $row) {
+            if ($this->transformTableRow) {
+                $row = ($this->transformTableRow)($tableName, $row);
+
+                if ($row === null) {
+                    continue;
+                }
+            }
+
             $count++;
             $values = $this->prepareColumnValues($tableName, $columnTypes, $row);
             $valueList = implode(',', $values);
@@ -268,16 +276,13 @@ class TableDataDumper
      *
      * @param string $tableName Name of table which contains rows
      * @param array<string, array<string, mixed>> $columnTypes Column type info for the table
-     * @param array<string, mixed> $row Associative array of column names and values to be quoted
+     * @param array<string, mixed> $row Associative array of column names and values to be quoted,
+     *                                  already passed through the row transform hook
      * @return array<int, mixed> quoted values ready for the VALUES list
      */
     private function prepareColumnValues(string $tableName, array $columnTypes, array $row): array
     {
         $ret = [];
-
-        if ($this->transformTableRow) {
-            $row = ($this->transformTableRow)($tableName, $row);
-        }
 
         $hexBlobEnabled = $this->settings->isEnabled('hex-blob');
         foreach ($row as $colName => $colValue) {

--- a/tests/TableDataDumperTest.php
+++ b/tests/TableDataDumperTest.php
@@ -144,6 +144,32 @@ class TableDataDumperTest extends TestCase
         $this->assertStringContainsString("(1,'JOHN')", $output);
     }
 
+    public function testTransformTableRowHookReturningNullSkipsRow(): void
+    {
+        $payloads = [];
+        $output = $this->dumpUsersTable(overrides: [
+            'transformTableRow' => fn(string $table, array $row): ?array =>
+                $row['id'] == 2 ? null : $row,
+            'info' => function (string $object, array $payload) use (&$payloads): void {
+                $payloads[] = $payload;
+            },
+        ]);
+
+        $this->assertStringContainsString("INSERT INTO `users` VALUES (1,'John');", $output);
+        $this->assertStringNotContainsString("O''Hara", $output);
+        // Skipped rows are not counted as dumped
+        $this->assertSame(['name' => 'users', 'completed' => true, 'rowCount' => 1], end($payloads));
+    }
+
+    public function testTransformTableRowHookSkippingAllRowsWritesNoInsert(): void
+    {
+        $output = $this->dumpUsersTable(overrides: [
+            'transformTableRow' => fn(string $table, array $row): ?array => null,
+        ]);
+
+        $this->assertStringNotContainsString('INSERT INTO', $output);
+    }
+
     public function testNullValuesAreDumpedAsNull(): void
     {
         $this->pdo->exec('INSERT INTO users VALUES (3, NULL)');


### PR DESCRIPTION
## Summary

Implements the row-filtering half of roadmap task 21: `setTransformTableRowHook()` callables may now return `null` to drop a row from the dump entirely.

- The row transform now runs at the top of the insert-writing loop in `TableDataDumper` (instead of inside `prepareColumnValues()`), so a `null` return skips the row before it is counted or serialized.
- Skipped rows are excluded from the `-- Dumped table ... with N row(s)` comments and from the info hook's `rowCount`.
- Dumps without a hook are byte-for-byte unchanged — full integration suite (43 tests vs native mysqldump) passes against MySQL 8.0.
- README gains a "Filtering rows when exporting" section, including the advice to prefer `where`/`setTableWheres()` when the condition is expressible in SQL.
- Task 21 row-filtering bullet checked off in `docs/tasks.md` (anonymization recipes remain open).

## Test plan

- [x] PHPUnit in php84 container: 91 tests incl. two new ones (skip one row + verify rowCount; skip all rows writes no INSERT)
- [x] PHPStan level 6 clean
- [x] Rector dry-run clean
- [x] `tests/scripts/test.sh mysql` — all 43 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)