### PR TITLE
feat: add dependency-free Anonymizer helpers for GDPR-sanitizing dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,41 @@ $dumper->setTransformTableRowHook(function ($tableName, array $row) {
 $dumper->start('storage/work/dump.sql');
 ```
 
+### Anonymization recipes
+
+For the common GDPR-sanitization cases the `Anonymizer` class provides ready-made,
+dependency-free helpers. `Anonymizer::columnMap()` builds a row-transform hook from a
+`table => column => transformer` map; tables and columns not in the map pass through untouched:
+
+```php
+use Druidfi\Mysqldump\Anonymizer;
+
+$dumper->setTransformTableRowHook(Anonymizer::columnMap([
+    'customers' => [
+        'email' => Anonymizer::email(),          // user-1a2b3c4d5e6f@example.com
+        'phone' => Anonymizer::mask(3),          // 040********
+        'social_security_number' => Anonymizer::fixed('REDACTED'),
+    ],
+    'users' => [
+        'name' => Anonymizer::hash('my-secret-salt'),
+        // Any callable(mixed $value, array $row): mixed works alongside the helpers
+        'display_name' => fn ($value, array $row) => 'user-' . $row['id'],
+    ],
+]));
+```
+
+Notes on the helpers:
+
+- All of them keep `NULL` values as `NULL`, so nullability semantics survive anonymization.
+- `hash()` and `email()` are deterministic — the same input always produces the same output —
+  so unique indexes and joins on the anonymized values keep working across tables and dumps.
+- Deterministic output of guessable data (names, phone numbers, SSNs) can be re-identified by
+  hashing candidate values, so pass a secret salt for those columns.
+- `mask()` preserves the string length, keeping the dump's data shape realistic.
+
+Anonymization here means the dump never contains the original values; it is not a substitute
+for access control on the source database itself.
+
 ## Filtering rows when exporting
 
 The same hook can drop rows entirely: return `null` instead of the row and it is left out of

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Notes on the helpers:
 Anonymization here means the dump never contains the original values; it is not a substitute
 for access control on the source database itself.
 
+For realistic-looking fake data (names, addresses, phone numbers) the hooks combine well with
+[FakerPHP](https://fakerphp.org/) — see [docs/faker.md](docs/faker.md) for recipes, including
+how to keep Faker output deterministic so joins and unique indexes survive.
+
 ## Filtering rows when exporting
 
 The same hook can drop rows entirely: return `null` instead of the row and it is left out of

--- a/docs/faker.md
+++ b/docs/faker.md
@@ -1,0 +1,124 @@
+# Using Faker for anonymization
+
+The transform hooks accept any callable, so [FakerPHP](https://fakerphp.org/) plugs straight
+into `Anonymizer::columnMap()` when you want realistic-looking fake data instead of the
+masked/hashed output of the built-in helpers. Faker is not a dependency of this library —
+add it to your own project:
+
+```bash
+composer require --dev fakerphp/faker
+```
+
+## Basic usage
+
+Create the Faker generator once, outside the hook — the hook runs for every dumped row:
+
+```php
+use Druidfi\Mysqldump\Anonymizer;
+use Druidfi\Mysqldump\Mysqldump;
+use Faker\Factory;
+
+$faker = Factory::create('fi_FI');
+
+$dumper = new Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
+
+$dumper->setTransformTableRowHook(Anonymizer::columnMap([
+    'customers' => [
+        'name'    => fn () => $faker->name(),
+        'phone'   => fn () => $faker->phoneNumber(),
+        'address' => fn () => $faker->streetAddress(),
+        // Faker and the built-in helpers mix freely in one map
+        'social_security_number' => Anonymizer::fixed('REDACTED'),
+    ],
+]));
+
+$dumper->start('storage/work/dump.sql');
+```
+
+Transformers are called as `function (mixed $value, array $row): mixed`; PHP ignores the
+extra arguments passed to zero-argument closures, so plain `fn () => $faker->name()` works.
+
+The same works without `columnMap()` in a plain hook, which is how Faker has typically been
+combined with this library:
+
+```php
+$dumper->setTransformTableRowHook(function (string $tableName, array $row) use ($faker) {
+    if ($tableName === 'customers') {
+        $row['name'] = $faker->name();
+    }
+
+    return $row;
+});
+```
+
+## Preserving NULLs
+
+Unlike the built-in helpers, a zero-argument Faker closure replaces `NULL` with a fake value,
+silently changing nullability semantics. Wrap it when that matters:
+
+```php
+'name' => fn ($value) => $value === null ? null : $faker->name(),
+```
+
+## Deterministic output (referential integrity)
+
+Faker output is random: if the same email appears in `customers` and `orders`, each
+occurrence gets a different fake value and the join is gone. Seeding Faker from the original
+value makes the mapping deterministic — same input, same fake output, across tables and
+across dumps:
+
+```php
+$fakeEmail = function ($value) use ($faker) {
+    if ($value === null) {
+        return null;
+    }
+    $faker->seed(crc32('my-secret-salt' . $value));
+
+    return $faker->safeEmail();
+};
+
+$dumper->setTransformTableRowHook(Anonymizer::columnMap([
+    'customers' => ['email' => $fakeEmail],
+    'orders'    => ['customer_email' => $fakeEmail],
+]));
+```
+
+This gives Faker's realistic output with the same determinism guarantee as
+`Anonymizer::email()` — including the same caveat: deterministic output of guessable values
+(names, phone numbers) can be re-identified by seeding the same way, so keep a secret salt
+in the seed.
+
+## Unique values
+
+`$faker->unique()->safeEmail()` throws an `OverflowException` once it cannot find a fresh
+value (it retries 10,000 times), which bites on large tables. The seeded approach above
+sidesteps the problem: distinct inputs produce distinct seeds, and `crc32` collisions are
+rare enough for test data. Where a unique index must hold strictly, derive the value from
+the row's primary key instead:
+
+```php
+'email' => fn ($value, array $row) => $value === null ? null : sprintf('user-%d@example.com', $row['id']),
+```
+
+## Row-dependent output
+
+The second argument is the full (untransformed) row, so fake data can depend on other
+columns — for example locale-appropriate names:
+
+```php
+use Faker\Factory;
+
+$generators = [];
+
+$fakeName = function ($value, array $row) use (&$generators) {
+    if ($value === null) {
+        return null;
+    }
+    $locale = $row['locale'] ?? 'en_US';
+    $generators[$locale] ??= Factory::create($locale);
+
+    return $generators[$locale]->name();
+};
+```
+
+(Generators are cached per locale — `Factory::create()` is far too expensive to call per row.)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -195,8 +195,12 @@ codebase; items that are done are kept checked for history.
     - [x] Support for LZ4 compression
     - [x] Configurable compression levels
 
-21. [ ] Enhance data transformation capabilities:
-    - [ ] Provide ready-made anonymization helpers/recipes on top of the existing hooks
+21. [x] Enhance data transformation capabilities:
+    - [x] Provide ready-made anonymization helpers/recipes on top of the existing hooks —
+          new dependency-free `Anonymizer` class: `columnMap()` builds a row-transform hook
+          from a table => column => transformer map; value helpers `fixed()`, `mask()`,
+          `hash()` and `email()` preserve NULLs, and the deterministic ones preserve
+          uniqueness/joins (README "Anonymization recipes" documents the salting caveat)
     - [x] Support returning `null` from hooks to skip a row entirely (row filtering) —
           `transformTableRowHook` may now return `null` to drop the row from the dump;
           skipped rows are excluded from row-count comments and the info hook's `rowCount`

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace Druidfi\Mysqldump;
+
+use Closure;
+
+/**
+ * Ready-made anonymization helpers on top of the transform hooks.
+ *
+ * columnMap() builds a row-transform hook from a per-table column map, and the
+ * value helpers (fixed, mask, hash, email) cover the common GDPR-sanitization
+ * cases without pulling in a faker-style dependency. All value helpers keep
+ * NULL values as NULL so nullability semantics survive anonymization.
+ *
+ * hash() and email() are deterministic (same input, same output), so
+ * uniqueness constraints and joins on the anonymized values keep working.
+ * Deterministic output of low-entropy data (names, phone numbers) can be
+ * re-identified by hashing candidate values — pass a secret salt to prevent
+ * that.
+ */
+final class Anonymizer
+{
+    /**
+     * Build a hook for Mysqldump::setTransformTableRowHook() from a map of
+     * table => column => value transformer.
+     *
+     * Tables and columns not present in the map pass through untouched, as do
+     * mapped columns that do not exist in a row. Each transformer is called as
+     * function(mixed $value, array $row): mixed with the untransformed row.
+     *
+     * @param array<string, array<string, callable>> $map table => column => transformer
+     */
+    public static function columnMap(array $map): Closure
+    {
+        return function (string $tableName, array $row) use ($map): array {
+            foreach ($map[$tableName] ?? [] as $column => $transform) {
+                if (array_key_exists($column, $row)) {
+                    $row[$column] = $transform($row[$column], $row);
+                }
+            }
+
+            return $row;
+        };
+    }
+
+    /**
+     * Replace every non-NULL value with a constant.
+     */
+    public static function fixed(mixed $value): Closure
+    {
+        return fn (mixed $current): mixed => $current === null ? null : $value;
+    }
+
+    /**
+     * Mask a string keeping its length and optionally a leading prefix,
+     * e.g. mask(2) turns "0401234567" into "04********".
+     */
+    public static function mask(int $keepPrefix = 0, string $maskChar = '*'): Closure
+    {
+        return function (mixed $current) use ($keepPrefix, $maskChar): mixed {
+            if ($current === null) {
+                return null;
+            }
+
+            $value = (string) $current;
+            // ext-mbstring is not a dependency; split UTF-8 with PCRE and
+            // fall back to bytes for non-UTF-8 data
+            $chars = preg_split('//u', $value, -1, PREG_SPLIT_NO_EMPTY);
+
+            if ($chars === false) {
+                $chars = str_split($value);
+            }
+
+            $prefix = implode('', array_slice($chars, 0, max(0, $keepPrefix)));
+
+            return $prefix . str_repeat($maskChar, max(0, count($chars) - $keepPrefix));
+        };
+    }
+
+    /**
+     * Replace a value with a deterministic SHA-256 hex digest, preserving
+     * uniqueness and joins across tables. Pass a secret salt when the input
+     * values are guessable.
+     */
+    public static function hash(string $salt = ''): Closure
+    {
+        return fn (mixed $current): mixed => $current === null
+            ? null
+            : hash('sha256', $salt . (string) $current);
+    }
+
+    /**
+     * Replace a value with a deterministic, syntactically valid email address
+     * such as "user-1a2b3c4d5e6f@example.com". Uniqueness is preserved, so
+     * unique indexes on email columns keep working.
+     */
+    public static function email(string $domain = 'example.com', string $salt = ''): Closure
+    {
+        return fn (mixed $current): mixed => $current === null
+            ? null
+            : sprintf('user-%s@%s', substr(hash('sha256', $salt . (string) $current), 0, 12), $domain);
+    }
+}

--- a/tests/AnonymizerTest.php
+++ b/tests/AnonymizerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Druidfi\Mysqldump\Tests;
+
+use Druidfi\Mysqldump\Anonymizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Anonymizer::class)]
+class AnonymizerTest extends TestCase
+{
+    public function testColumnMapTransformsMappedColumns(): void
+    {
+        $hook = Anonymizer::columnMap([
+            'customers' => [
+                'email' => Anonymizer::email(),
+                'ssn' => Anonymizer::fixed('REDACTED'),
+            ],
+        ]);
+
+        $row = $hook('customers', ['id' => 1, 'email' => 'john@real.example', 'ssn' => '010101-123X']);
+
+        $this->assertSame(1, $row['id']);
+        $this->assertMatchesRegularExpression('/^user-[0-9a-f]{12}@example\.com$/', $row['email']);
+        $this->assertSame('REDACTED', $row['ssn']);
+    }
+
+    public function testColumnMapLeavesUnmappedTablesUntouched(): void
+    {
+        $hook = Anonymizer::columnMap(['customers' => ['email' => Anonymizer::fixed('x')]]);
+
+        $row = ['id' => 1, 'email' => 'john@real.example'];
+
+        $this->assertSame($row, $hook('orders', $row));
+    }
+
+    public function testColumnMapIgnoresMappedColumnsMissingFromRow(): void
+    {
+        $hook = Anonymizer::columnMap(['customers' => ['missing' => Anonymizer::fixed('x')]]);
+
+        $row = ['id' => 1];
+
+        $this->assertSame($row, $hook('customers', $row));
+    }
+
+    public function testColumnMapPassesValueAndRowToTransformer(): void
+    {
+        $hook = Anonymizer::columnMap([
+            'users' => [
+                'display_name' => fn (mixed $value, array $row): string => 'user-' . $row['id'],
+            ],
+        ]);
+
+        $row = $hook('users', ['id' => 7, 'display_name' => 'John Doe']);
+
+        $this->assertSame('user-7', $row['display_name']);
+    }
+
+    public function testFixedPreservesNull(): void
+    {
+        $transform = Anonymizer::fixed('x');
+
+        $this->assertSame('x', $transform('secret'));
+        $this->assertNull($transform(null));
+    }
+
+    public function testMaskKeepsLengthAndPrefix(): void
+    {
+        $transform = Anonymizer::mask(2);
+
+        $this->assertSame('04********', $transform('0401234567'));
+        $this->assertSame('ab', $transform('ab'));
+        $this->assertNull($transform(null));
+    }
+
+    public function testMaskWithoutPrefixMasksEverything(): void
+    {
+        $transform = Anonymizer::mask();
+
+        $this->assertSame('******', $transform('secret'));
+    }
+
+    public function testMaskCountsMultibyteCharactersNotBytes(): void
+    {
+        $transform = Anonymizer::mask(1);
+
+        $this->assertSame('Ä***', $transform('Äiti'));
+    }
+
+    public function testHashIsDeterministicAndSalted(): void
+    {
+        $plain = Anonymizer::hash();
+        $salted = Anonymizer::hash('pepper');
+
+        $this->assertSame($plain('john'), $plain('john'));
+        $this->assertSame(hash('sha256', 'john'), $plain('john'));
+        $this->assertNotSame($plain('john'), $salted('john'));
+        $this->assertNull($plain(null));
+    }
+
+    public function testEmailIsDeterministicValidAndUnique(): void
+    {
+        $transform = Anonymizer::email();
+
+        $this->assertSame($transform('john@real.example'), $transform('john@real.example'));
+        $this->assertNotSame($transform('john@real.example'), $transform('jane@real.example'));
+        $this->assertMatchesRegularExpression('/^user-[0-9a-f]{12}@example\.com$/', $transform('john@real.example'));
+        $this->assertNull($transform(null));
+    }
+
+    public function testEmailUsesCustomDomainAndSalt(): void
+    {
+        $plain = Anonymizer::email();
+        $custom = Anonymizer::email('anon.invalid', 'pepper');
+
+        $this->assertStringEndsWith('@anon.invalid', $custom('john@real.example'));
+        $this->assertNotSame($plain('john@real.example'), $custom('john@real.example'));
+    }
+}

--- a/tests/TableDataDumperTest.php
+++ b/tests/TableDataDumperTest.php
@@ -2,6 +2,7 @@
 
 namespace Druidfi\Mysqldump\Tests;
 
+use Druidfi\Mysqldump\Anonymizer;
 use Druidfi\Mysqldump\DumpSettings;
 use Druidfi\Mysqldump\DumpWriter;
 use Druidfi\Mysqldump\TableDataDumper;
@@ -168,6 +169,18 @@ class TableDataDumperTest extends TestCase
         ]);
 
         $this->assertStringNotContainsString('INSERT INTO', $output);
+    }
+
+    public function testAnonymizerColumnMapWorksAsRowTransformHook(): void
+    {
+        $output = $this->dumpUsersTable(overrides: [
+            'transformTableRow' => Anonymizer::columnMap([
+                'users' => ['name' => Anonymizer::fixed('anonymous')],
+            ]),
+        ]);
+
+        $this->assertStringContainsString("(1,'anonymous'),(2,'anonymous')", $output);
+        $this->assertStringNotContainsString('John', $output);
     }
 
     public function testNullValuesAreDumpedAsNull(): void


### PR DESCRIPTION
## Summary

Completes roadmap task 21 (the anonymization helpers/recipes bullet) — motivated by the library's primary real-world use: GDPR-sanitizing/anonymizing row data via the transform hooks.

- New `Druidfi\Mysqldump\Anonymizer` class, dependency-free (no faker-style packages):
  - `columnMap()` builds a `setTransformTableRowHook()` callable from a `table => column => transformer` map; unmapped tables/columns pass through untouched, and custom callables compose with the built-in helpers.
  - Value helpers: `fixed()`, `mask()` (length-preserving; multibyte-safe via PCRE since ext-mbstring is not a dependency), `hash()` and `email()`.
  - All helpers keep `NULL` as `NULL`; `hash()`/`email()` are deterministic so unique indexes and joins survive anonymization, with a salt parameter against re-identification of guessable values.
- README "Anonymization recipes" section with a worked example and the salting caveat.
- Task 21 fully checked off in `docs/tasks.md`.

The dumper code paths are untouched — the helper is purely opt-in, so dump output is unaffected.

## Test plan

- [x] PHPUnit in php84 container: 103 tests, 12 new (AnonymizerTest unit coverage + an end-to-end test running `columnMap()` through `TableDataDumper`)
- [x] PHPStan level 6 clean
- [x] Rector dry-run clean
- [x] CI runs the full integration matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)